### PR TITLE
Respect provided limit in /api/runs endpoint

### DIFF
--- a/webapp/main.py
+++ b/webapp/main.py
@@ -216,14 +216,16 @@ async def get_devices():
 
 @app.get("/api/runs/{command}")
 async def get_runs(
-    command: str, device: Optional[str] = None, limit: int = DEFAULT_HISTORY_SIZE
+    command: str, device: Optional[str] = None, limit: Optional[int] = None
 ):
     """Get command runs for a specific command."""
-    try:
-        cfg = load_config()
-        limit = cfg.get_history_size()
-    except (FileNotFoundError, PermissionError, YAMLError) as exc:
-        logger.warning("Config fallback for /api/runs: %s", exc)
+    if limit is None:
+        try:
+            cfg = load_config()
+            limit = cfg.get_history_size()
+        except (FileNotFoundError, PermissionError, YAMLError) as exc:
+            logger.warning("Config fallback for /api/runs: %s", exc)
+            limit = DEFAULT_HISTORY_SIZE
 
     db = get_db(history_size=limit)
     if not db:


### PR DESCRIPTION
### Motivation

- Ensure the `/api/runs` endpoint respects a caller-provided `limit` instead of always using the configured history size.
- Avoid overriding an explicit `limit` parameter with configuration values.
- Preserve the existing fallback behavior when loading the configuration fails.
- Guarantee the resolved `limit` is used for database calls.

### Description

- Changed the `get_runs` signature to accept `limit: Optional[int] = None` instead of a fixed default.
- Only call `load_config()` and use `cfg.get_history_size()` when `limit` is `None`, and set `limit = DEFAULT_HISTORY_SIZE` on config errors.
- Continue to pass the resolved `limit` into `get_db(history_size=limit)` and `db.get_latest_runs(..., limit=limit, ...)`.
- No other call sites or endpoint behavior were altered.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963013fdd208330b78829f01cbeed11)