### PR TITLE
Make collector thread pool size configurable via `collector.max_workers`

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,15 @@ nw-watch/
 - `history_size`: Number of runs to keep per device/command
 - `max_output_lines`: Max lines retained after filtering (truncates above this)
 
+### Collector settings (optional)
+
+Configure the ThreadPoolExecutor used for running command collections in parallel:
+
+```yaml
+collector:
+  max_workers: 20  # Max ThreadPoolExecutor workers (default: 20)
+```
+
 ### WebSocket settings (optional)
 
 Enable WebSocket for real-time updates instead of polling:
@@ -669,7 +678,7 @@ graph TB
 ### Data Flow
 
 1. **Collector** connects to devices via SSH using Netmiko
-2. Commands are executed in parallel using ThreadPoolExecutor (configurable max workers: 20)
+2. Commands are executed in parallel using ThreadPoolExecutor (configurable via `collector.max_workers`, default: 20)
 3. Raw outputs are processed through filtering and truncation pipeline
 4. Results are stored in session-specific SQLite database (`session_{epoch}.sqlite3`)
 5. Session database is atomically copied to `current.sqlite3` after each collection cycle

--- a/collector/main.py
+++ b/collector/main.py
@@ -332,7 +332,7 @@ class Collector:
         )
         logger.info(f"Created session database: {self.session_db_path}")
 
-        self.executor = ThreadPoolExecutor(max_workers=20)
+        self.executor = ThreadPoolExecutor(max_workers=self.config.get_max_workers())
         self.running = True
         self.commands: List[str] = self._resolve_commands()
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -7,6 +7,10 @@ ping_window_seconds: 60          # Window (seconds) for ping tiles
 history_size: 10                 # Max runs per device/command to keep
 max_output_lines: 500            # Truncate outputs after filtering
 
+# Collector settings (optional)
+collector:
+  max_workers: 20                # Max ThreadPoolExecutor workers (default: 20)
+
 # WebSocket settings (optional)
 websocket:
   enabled: false                 # Enable WebSocket for real-time updates (default: false)

--- a/shared/config.py
+++ b/shared/config.py
@@ -99,6 +99,15 @@ class Config:
             )
         )
 
+    def get_max_workers(self) -> int:
+        """ThreadPoolExecutor max workers for command execution."""
+        return int(
+            self.data.get(
+                "collector",
+                {},
+            ).get("max_workers", 20)
+        )
+
     # ------------------------------------------------------------------ #
     # WebSocket settings
     # ------------------------------------------------------------------ #

--- a/shared/validation.py
+++ b/shared/validation.py
@@ -209,6 +209,20 @@ class SSHConfig(BaseModel):
         return v
 
 
+class CollectorConfig(BaseModel):
+    """Collector configuration."""
+
+    max_workers: int = Field(default=20, gt=0)
+
+    @field_validator("max_workers")
+    @classmethod
+    def validate_max_workers(cls, v: int) -> int:
+        """Validate max workers is positive."""
+        if v <= 0:
+            raise ValueError(f"collector max_workers must be positive, got {v}")
+        return v
+
+
 class ConfigSchema(BaseModel):
     """Root configuration schema."""
 
@@ -223,12 +237,12 @@ class ConfigSchema(BaseModel):
     )
     websocket: Optional[WebSocketConfig] = Field(default_factory=WebSocketConfig)
     ssh: Optional[SSHConfig] = Field(default_factory=SSHConfig)
+    collector: Optional[CollectorConfig] = Field(default_factory=CollectorConfig)
 
     commands: List[CommandConfig] = Field(default_factory=list)
     devices: List[DeviceConfig] = Field(default_factory=list)
 
     # Legacy fields for backward compatibility
-    collector: Optional[Dict[str, Any]] = None
     webapp: Optional[Dict[str, Any]] = None
     filters: Optional[Dict[str, Any]] = None
 


### PR DESCRIPTION
### Motivation

- Allow tuning the number of worker threads used for command execution instead of hard-coding `max_workers=20`.
- Expose the setting in the validated configuration schema so users can set it in `config.yaml`.
- Keep documentation consistent with actual runtime behavior by updating the README and example config.

### Description

- Add a `CollectorConfig` Pydantic model with `max_workers` and include it on the root `ConfigSchema` in `shared/validation.py`.
- Add `get_max_workers()` accessor to `shared/config.py` that reads `collector.max_workers` with a default of `20`.
- Wire the value into the collector initialization by using `ThreadPoolExecutor(max_workers=self.config.get_max_workers())` in `collector/main.py`.
- Document the new `collector.max_workers` option in `README.md` and `config.example.yaml` and update the data-flow line to reference the configurable setting.

### Testing

- No automated tests were run against these changes.
- The repository contains a test suite runnable via `pytest` if maintainers wish to execute it after review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69630149d42c8330a723b716ab06008e)