### PR TITLE
[codex] Restrict web port binding to loopback

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ graph LR
     subgraph "nw-watch System"
         C[📡 Collector<br/>SSH + Ping<br/>every 5s]
         DB[(💾 SQLite<br/>History)]
-        W[🌐 Web UI<br/>localhost:8000]
+        W[🌐 Web UI<br/>127.0.0.1:8000]
     end
     
     subgraph "User"
@@ -176,7 +176,7 @@ This will:
 Open your browser and navigate to:
 
 ```
-http://localhost:8000
+http://127.0.0.1:8000
 ```
 
 6. **View logs**
@@ -626,16 +626,16 @@ The collector control endpoints allow pausing/resuming command execution and req
 
 ```bash
 # Check collector status
-curl "http://localhost:8000/api/collector/status"
+curl "http://127.0.0.1:8000/api/collector/status"
 
 # Pause command execution
-curl -X POST "http://localhost:8000/api/collector/pause"
+curl -X POST "http://127.0.0.1:8000/api/collector/pause"
 
 # Resume command execution
-curl -X POST "http://localhost:8000/api/collector/resume"
+curl -X POST "http://127.0.0.1:8000/api/collector/resume"
 
 # Request collector shutdown
-curl -X POST "http://localhost:8000/api/collector/stop"
+curl -X POST "http://127.0.0.1:8000/api/collector/stop"
 ```
 
 The control state is stored in `./control/collector_control.json`. Set `NW_WATCH_CONTROL_DIR` to customize the location.
@@ -647,33 +647,33 @@ The export functionality is available via REST API endpoints:
 **Export Individual Run:**
 ```bash
 # Text format
-curl "http://localhost:8000/api/export/run?command=show%20version&device=DeviceA&format=text" -o output.txt
+curl "http://127.0.0.1:8000/api/export/run?command=show%20version&device=DeviceA&format=text" -o output.txt
 
 # JSON format
-curl "http://localhost:8000/api/export/run?command=show%20version&device=DeviceA&format=json" -o output.json
+curl "http://127.0.0.1:8000/api/export/run?command=show%20version&device=DeviceA&format=json" -o output.json
 ```
 
 **Export Bulk Runs (All Devices):**
 ```bash
-curl "http://localhost:8000/api/export/bulk?command=show%20version&format=json" -o bulk_export.json
+curl "http://127.0.0.1:8000/api/export/bulk?command=show%20version&format=json" -o bulk_export.json
 ```
 
 **Export Diff:**
 ```bash
 # History diff (Previous vs Latest)
-curl "http://localhost:8000/api/export/diff?command=show%20version&device=DeviceA&format=html" -o diff.html
+curl "http://127.0.0.1:8000/api/export/diff?command=show%20version&device=DeviceA&format=html" -o diff.html
 
 # Device diff (DeviceA vs DeviceB)
-curl "http://localhost:8000/api/export/diff?command=show%20version&device_a=DeviceA&device_b=DeviceB&format=html" -o diff.html
+curl "http://127.0.0.1:8000/api/export/diff?command=show%20version&device_a=DeviceA&device_b=DeviceB&format=html" -o diff.html
 ```
 
 **Export Ping Data:**
 ```bash
 # CSV format (last hour)
-curl "http://localhost:8000/api/export/ping?device=DeviceA&format=csv&window_seconds=3600" -o ping_data.csv
+curl "http://127.0.0.1:8000/api/export/ping?device=DeviceA&format=csv&window_seconds=3600" -o ping_data.csv
 
 # JSON format (last 24 hours)
-curl "http://localhost:8000/api/export/ping?device=DeviceA&format=json&window_seconds=86400" -o ping_data.json
+curl "http://127.0.0.1:8000/api/export/ping?device=DeviceA&format=json&window_seconds=86400" -o ping_data.json
 ```
 
 ## Architecture

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     build: .
     container_name: nw-watch-webapp
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"
     volumes:
       # Data directory mounted read-only - webapp only reads from database
       - ./data:/app/data:ro

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -30,7 +30,7 @@ graph LR
     subgraph "nw-watch システム"
         C[📡 コレクター<br/>SSH + Ping<br/>5秒ごと]
         DB[(💾 SQLite<br/>履歴保存)]
-        W[🌐 Web UI<br/>localhost:8000]
+        W[🌐 Web UI<br/>127.0.0.1:8000]
     end
     
     subgraph "ユーザー"
@@ -161,7 +161,7 @@ docker-compose up -d
 ブラウザで以下のURLにアクセスします:
 
 ```
-http://localhost:8000
+http://127.0.0.1:8000
 ```
 
 6. **ログを表示**
@@ -593,16 +593,16 @@ pytest --cov=shared --cov=collector --cov=webapp
 
 ```bash
 # 状態確認
-curl "http://localhost:8000/api/collector/status"
+curl "http://127.0.0.1:8000/api/collector/status"
 
 # コマンド実行を一時停止
-curl -X POST "http://localhost:8000/api/collector/pause"
+curl -X POST "http://127.0.0.1:8000/api/collector/pause"
 
 # コマンド実行を再開
-curl -X POST "http://localhost:8000/api/collector/resume"
+curl -X POST "http://127.0.0.1:8000/api/collector/resume"
 
 # コレクター停止を要求
-curl -X POST "http://localhost:8000/api/collector/stop"
+curl -X POST "http://127.0.0.1:8000/api/collector/stop"
 ```
 
 制御情報は `./control/collector_control.json` に保存されます。`NW_WATCH_CONTROL_DIR` で保存先を変更できます。
@@ -614,33 +614,33 @@ curl -X POST "http://localhost:8000/api/collector/stop"
 **個別実行のエクスポート:**
 ```bash
 # テキスト形式
-curl "http://localhost:8000/api/export/run?command=show%20version&device=DeviceA&format=text" -o output.txt
+curl "http://127.0.0.1:8000/api/export/run?command=show%20version&device=DeviceA&format=text" -o output.txt
 
 # JSON形式
-curl "http://localhost:8000/api/export/run?command=show%20version&device=DeviceA&format=json" -o output.json
+curl "http://127.0.0.1:8000/api/export/run?command=show%20version&device=DeviceA&format=json" -o output.json
 ```
 
 **一括実行のエクスポート（すべてのデバイス）:**
 ```bash
-curl "http://localhost:8000/api/export/bulk?command=show%20version&format=json" -o bulk_export.json
+curl "http://127.0.0.1:8000/api/export/bulk?command=show%20version&format=json" -o bulk_export.json
 ```
 
 **差分のエクスポート:**
 ```bash
 # 履歴差分（前回 vs 最新）
-curl "http://localhost:8000/api/export/diff?command=show%20version&device=DeviceA&format=html" -o diff.html
+curl "http://127.0.0.1:8000/api/export/diff?command=show%20version&device=DeviceA&format=html" -o diff.html
 
 # デバイス差分（DeviceA vs DeviceB）
-curl "http://localhost:8000/api/export/diff?command=show%20version&device_a=DeviceA&device_b=DeviceB&format=html" -o diff.html
+curl "http://127.0.0.1:8000/api/export/diff?command=show%20version&device_a=DeviceA&device_b=DeviceB&format=html" -o diff.html
 ```
 
 **Pingデータのエクスポート:**
 ```bash
 # CSV形式（過去1時間）
-curl "http://localhost:8000/api/export/ping?device=DeviceA&format=csv&window_seconds=3600" -o ping_data.csv
+curl "http://127.0.0.1:8000/api/export/ping?device=DeviceA&format=csv&window_seconds=3600" -o ping_data.csv
 
 # JSON形式（過去24時間）
-curl "http://localhost:8000/api/export/ping?device=DeviceA&format=json&window_seconds=86400" -o ping_data.json
+curl "http://127.0.0.1:8000/api/export/ping?device=DeviceA&format=json&window_seconds=86400" -o ping_data.json
 ```
 
 ## アーキテクチャ

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,3 +1,16 @@
+<!--
+Copyright 2026 icecake0141
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+This file was created or modified with the assistance of an AI (Large Language Model).
+Review required for correctness, security, and licensing.
+-->
 # Troubleshooting Guide
 
 This guide provides solutions to common issues you may encounter when using nw-watch.
@@ -542,7 +555,7 @@ This guide provides solutions to common issues you may encounter when using nw-w
    services:
      webapp:
        ports:
-         - "8080:8000"  # Use port 8080 on host
+         - "127.0.0.1:8080:8000"  # Use port 8080 on host loopback only
    ```
 
 ## Web Interface Issues

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -1,3 +1,14 @@
+# Copyright 2026 icecake0141
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
 """Tests for Docker functionality."""
 
 import os
@@ -83,7 +94,9 @@ class TestDockerConfiguration:
         """Test that docker-compose.yml maps ports."""
         compose_file = Path(__file__).parent.parent / "docker-compose.yml"
         content = compose_file.read_text()
-        assert "8000:8000" in content, "docker-compose.yml should map port 8000"
+        assert (
+            "127.0.0.1:8000:8000" in content
+        ), "docker-compose.yml should map port 8000 to host loopback only"
 
     def test_dockerignore_excludes_git(self):
         """Test that .dockerignore excludes .git directory."""
@@ -214,13 +227,15 @@ class TestDockerComposeConfiguration:
         assert "--config" in content, "Collector should use config file"
 
     def test_docker_compose_webapp_command(self):
-        """Test that webapp service has correct command."""
+        """Test that webapp service has correct in-container command."""
         compose_file = Path(__file__).parent.parent / "docker-compose.yml"
         content = compose_file.read_text()
         assert (
             "uvicorn nw_watch.webapp.main:app" in content
         ), "Webapp should run via uvicorn"
-        assert "--host 0.0.0.0" in content, "Webapp should listen on all interfaces"
+        assert (
+            "--host 0.0.0.0" in content
+        ), "Webapp should listen on container interfaces for Docker port forwarding"
 
     def test_docker_compose_has_restart_policy(self):
         """Test that services have restart policy."""


### PR DESCRIPTION
## Summary
- Restrict Docker Compose host port publishing for the web UI to 127.0.0.1.
- Update README examples in English and Japanese to use 127.0.0.1 consistently.
- Update Docker configuration tests to assert loopback-only host binding while keeping the container-internal uvicorn bind for port forwarding.

## Rationale
Binding the published Docker port to all host interfaces can expose the web UI beyond the local machine. Docker still needs uvicorn to listen on the container interface, so this PR limits exposure at the host port mapping layer.

## Validation
- Passed: `pytest tests/test_docker.py -q`
- Passed: `git diff --check`
- Passed: `python -m black --check .`
- Failed: `python -m flake8 src tests` due to pre-existing style/import issues outside this change, including many E501 line-length findings and unused imports.
- Failed: `python -m mypy src` due to pre-existing type issues in shared/export.py, shared/db.py, collector/main.py, webapp/websocket_manager.py, and webapp/main.py.
- Pre-commit: no `.pre-commit-config.yaml` or `.pre-commit-config.yml` found.

## Documentation
- Updated README.md and docs/README.ja.md startup/access examples.
- Updated docs/TROUBLESHOOTING.md alternate port example to keep host loopback binding.

## Compatibility
Existing local access remains `http://127.0.0.1:8000`. Access from other machines on the network is intentionally no longer available through the default Docker Compose port mapping.

## LLM involvement
Files modified with LLM assistance: README.md, docker-compose.yml, docs/README.ja.md, docs/TROUBLESHOOTING.md, tests/test_docker.py. Review performed by inspecting diffs and running the validation commands above.

## Checklist
- [x] License header added to new/modified files where applicable and top-level LICENSE present
- [x] LLM attribution added to modified/generated files where applicable
- [ ] Linting completed - score: not 10/10; `python -m flake8 src tests` currently fails on existing issues
- [x] Tests pass locally: `pytest tests/test_docker.py -q`
- [ ] Static analysis/type checks pass: `python -m mypy src` currently fails on existing issues
- [x] Formatting checked: `python -m black --check .`
- [x] Pre-commit hooks checked: no config found
- [ ] CI build passes
- [x] No merge conflicts with base branch at PR creation time
- [x] Changelog/versioning updated: not applicable
- [x] Documentation updated: README and troubleshooting docs
- [x] Examples/quick-start updated where applicable
- [x] Commit messages follow repository conventions
- [x] PR description includes summary, rationale, tests, docs, migration notes, and LLM-modified files
