### PR TITLE
[codex] Add manual command refresh mode

### DIFF
--- a/docs/collector-controls.ja.md
+++ b/docs/collector-controls.ja.md
@@ -35,6 +35,10 @@ Web UI には collector を制御する 3 つのボタンがあります。
 - `POST /api/collector/pause`
 - `POST /api/collector/resume`
 - `POST /api/collector/stop`
+- `POST /api/collector/mode`
+- `POST /api/collector/run_once`
+
+手動モードでは `manual_mode: true` が保存され、collector は通常スケジュールでのコマンド取得を停止します。Web UI に表示される `Run Commands Now` ボタンを押すと `manual_run_requested: true` が保存され、collector は次回ポーリング時に1回だけコマンド取得を実行してからリクエストをクリアします。
 
 ## 動作上の注意
 

--- a/docs/collector-controls.md
+++ b/docs/collector-controls.md
@@ -52,6 +52,8 @@ Format:
 ```json
 {
   "commands_paused": false,
+  "manual_mode": false,
+  "manual_run_requested": false,
   "shutdown_requested": false,
   "updated_at": 1769421307
 }
@@ -86,6 +88,26 @@ Format:
 3. Button changes back to "⏸ Pause Commands"
 4. Status changes to "Collector: Running"
 5. Collector resumes executing commands
+
+### Manual Mode Button
+
+**Initial State**: "Manual Mode: Off" (enabled)
+
+**When Clicked**:
+1. Sends POST request to `/api/collector/mode`
+2. Sets `manual_mode: true` in control state
+3. Shows the "▶ Run Commands Now" button
+4. Collector waits for a manual run request instead of collecting commands on schedule
+
+### Run Commands Now Button
+
+**Initial State**: Hidden until manual mode is enabled
+
+**When Clicked**:
+1. Sends POST request to `/api/collector/run_once`
+2. Sets `manual_run_requested: true` in control state
+3. Collector executes one command collection cycle on the next control poll
+4. Collector clears `manual_run_requested` after accepting the request
 
 ### Stop Collector Button
 
@@ -163,6 +185,8 @@ Returns current collector state:
 ```json
 {
   "commands_paused": false,
+  "manual_mode": false,
+  "manual_run_requested": false,
   "shutdown_requested": false,
   "status": "running",
   "updated_at": 1769421307
@@ -171,6 +195,7 @@ Returns current collector state:
 
 Status values:
 - `"running"`: Commands executing normally
+- `"manual"`: Commands execute only when manually requested
 - `"paused"`: Commands paused, ping continues
 - `"stopped"`: Shutdown requested, collector will terminate
 
@@ -222,6 +247,21 @@ Requests collector shutdown.
   "updated_at": 1769421307
 }
 ```
+
+### POST /api/collector/mode
+
+Switches automatic/manual command execution mode.
+
+**Request**:
+```json
+{
+  "manual_mode": true
+}
+```
+
+### POST /api/collector/run_once
+
+Requests one command collection cycle. This endpoint is valid only when manual mode is enabled and commands are not paused.
 
 ## Troubleshooting
 

--- a/docs/specification.ja.md
+++ b/docs/specification.ja.md
@@ -65,6 +65,8 @@ English: [specification.md](specification.md)
 - `POST /api/collector/pause`
 - `POST /api/collector/resume`
 - `POST /api/collector/stop`
+- `POST /api/collector/mode`
+- `POST /api/collector/run_once`
 - `GET /api/export/run`
 - `GET /api/export/bulk`
 - `GET /api/export/diff`

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -65,6 +65,8 @@ Reference example: [`config.example.yaml`](../config.example.yaml)
 - `POST /api/collector/pause`
 - `POST /api/collector/resume`
 - `POST /api/collector/stop`
+- `POST /api/collector/mode`
+- `POST /api/collector/run_once`
 - `GET /api/export/run`
 - `GET /api/export/bulk`
 - `GET /api/export/diff`

--- a/src/nw_watch/collector/main.py
+++ b/src/nw_watch/collector/main.py
@@ -28,7 +28,11 @@ from netmiko import ConnectHandler
 from netmiko.exceptions import NetmikoTimeoutException, NetmikoAuthenticationException
 
 from nw_watch.shared.config import Config
-from nw_watch.shared.control_state import DEFAULT_CONTROL_STATE, read_control_state
+from nw_watch.shared.control_state import (
+    DEFAULT_CONTROL_STATE,
+    read_control_state,
+    update_control_state,
+)
 from nw_watch.shared.db import Database
 from nw_watch.shared.filters import process_output
 
@@ -349,6 +353,7 @@ class Collector:
         self.running = True
         self.commands: List[str] = self._resolve_commands()
         self.commands_paused = False
+        self.manual_mode = False
         self.control_poll_interval = 2
 
         # Cache global interval to avoid repeated method calls
@@ -408,6 +413,14 @@ class Collector:
             else:
                 logger.info("Command execution resumed via control state.")
 
+        manual_mode = bool(state.get("manual_mode", False))
+        if manual_mode != self.manual_mode:
+            self.manual_mode = manual_mode
+            if manual_mode:
+                logger.info("Command execution switched to manual mode.")
+            else:
+                logger.info("Command execution switched to automatic mode.")
+
     def _resolve_commands(self) -> List[str]:
         """Build command list honoring global commands or per-device fallbacks."""
         configured_commands = self.config.get_commands()
@@ -427,7 +440,7 @@ class Collector:
                 seen.add(cmd)
         return ordered
 
-    async def collect_commands(self):
+    async def collect_commands(self, force: bool = False):
         """Collect commands from all devices (only commands due to run)."""
         loop = asyncio.get_event_loop()
         futures = []
@@ -438,7 +451,7 @@ class Collector:
             for command in self.commands:
                 # Check if this command should run now
                 next_run = self.command_next_run.get(command, now)
-                if now >= next_run:
+                if force or now >= next_run:
                     # Run in thread pool to avoid blocking
                     future = loop.run_in_executor(
                         self.executor, collector.execute_command, command, self.db
@@ -515,6 +528,20 @@ class Collector:
 
                     self._apply_control_state(control_state)
                     if self.commands_paused:
+                        await asyncio.sleep(self.control_poll_interval)
+                        continue
+
+                    if self.manual_mode:
+                        if not control_state.get("manual_run_requested"):
+                            await asyncio.sleep(self.control_poll_interval)
+                            continue
+                        await self.collect_commands(force=True)
+                        try:
+                            update_control_state({"manual_run_requested": False})
+                        except Exception as exc:
+                            logger.warning(
+                                "Failed to clear manual run request: %s", exc
+                            )
                         await asyncio.sleep(self.control_poll_interval)
                         continue
 

--- a/src/nw_watch/shared/control_state.py
+++ b/src/nw_watch/shared/control_state.py
@@ -26,6 +26,8 @@ CONTROL_DIR_ENV = "NW_WATCH_CONTROL_DIR"
 
 DEFAULT_CONTROL_STATE: Dict[str, Any] = {
     "commands_paused": False,
+    "manual_mode": False,
+    "manual_run_requested": False,
     "shutdown_requested": False,
     "updated_at": 0,
 }
@@ -42,6 +44,8 @@ def normalize_control_state(state: Dict[str, Any]) -> Dict[str, Any]:
     normalized = DEFAULT_CONTROL_STATE.copy()
     normalized.update({k: state.get(k, v) for k, v in DEFAULT_CONTROL_STATE.items()})
     normalized["commands_paused"] = bool(normalized.get("commands_paused"))
+    normalized["manual_mode"] = bool(normalized.get("manual_mode"))
+    normalized["manual_run_requested"] = bool(normalized.get("manual_run_requested"))
     normalized["shutdown_requested"] = bool(normalized.get("shutdown_requested"))
     normalized["updated_at"] = int(normalized.get("updated_at") or 0)
     return normalized

--- a/src/nw_watch/webapp/main.py
+++ b/src/nw_watch/webapp/main.py
@@ -189,6 +189,8 @@ def build_collector_status() -> Dict[str, object]:
         status = "stopped"
     elif state.get("commands_paused"):
         status = "paused"
+    elif state.get("manual_mode"):
+        status = "manual"
     state["status"] = status
     return state
 
@@ -570,9 +572,13 @@ async def resume_collector_commands():
     """Resume backend command execution."""
     try:
         updated = update_control_state(
-            {"commands_paused": False, "shutdown_requested": False}
+            {
+                "commands_paused": False,
+                "manual_run_requested": False,
+                "shutdown_requested": False,
+            }
         )
-        updated["status"] = "running"
+        updated["status"] = "manual" if updated.get("manual_mode") else "running"
         return JSONResponse(updated)
     except Exception as exc:
         logger.error("Failed to resume collector: %s", exc)
@@ -591,6 +597,56 @@ async def stop_collector():
     except Exception as exc:
         logger.error("Failed to stop collector: %s", exc)
         return JSONResponse({"error": "Failed to stop collector."}, status_code=500)
+
+
+@app.post("/api/collector/mode")
+async def set_collector_mode(request: Request):
+    """Set automatic or manual command execution mode."""
+    state = read_control_state()
+    if state.get("shutdown_requested"):
+        return JSONResponse(
+            {"error": "Collector shutdown already requested."}, status_code=409
+        )
+
+    try:
+        payload = await request.json()
+        manual_mode = bool(payload.get("manual_mode", False))
+        updated = update_control_state(
+            {"manual_mode": manual_mode, "manual_run_requested": False}
+        )
+        updated["status"] = build_collector_status()["status"]
+        return JSONResponse(updated)
+    except Exception as exc:
+        logger.error("Failed to set collector mode: %s", exc)
+        return JSONResponse({"error": "Failed to set collector mode."}, status_code=500)
+
+
+@app.post("/api/collector/run_once")
+async def run_collector_once():
+    """Request one manual command collection cycle."""
+    state = read_control_state()
+    if state.get("shutdown_requested"):
+        return JSONResponse(
+            {"error": "Collector shutdown already requested."}, status_code=409
+        )
+    if state.get("commands_paused"):
+        return JSONResponse(
+            {"error": "Collector commands are paused."}, status_code=409
+        )
+    if not state.get("manual_mode"):
+        return JSONResponse(
+            {"error": "Collector is not in manual mode."}, status_code=409
+        )
+
+    try:
+        updated = update_control_state({"manual_run_requested": True})
+        updated["status"] = "manual"
+        return JSONResponse(updated)
+    except Exception as exc:
+        logger.error("Failed to request manual collector run: %s", exc)
+        return JSONResponse(
+            {"error": "Failed to request manual collector run."}, status_code=500
+        )
 
 
 @app.get("/api/export/run")

--- a/src/nw_watch/webapp/static/app.js
+++ b/src/nw_watch/webapp/static/app.js
@@ -35,6 +35,8 @@ class NetworkWatch {
         this.collectorPollTimer = null;
         this.collectorState = {
             commands_paused: false,
+            manual_mode: false,
+            manual_run_requested: false,
             shutdown_requested: false,
             status: 'unknown',
             updated_at: 0
@@ -144,6 +146,14 @@ class NetworkWatch {
             this.toggleCollectorCommands();
         });
 
+        document.getElementById('toggleCollectorMode').addEventListener('click', () => {
+            this.toggleCollectorMode();
+        });
+
+        document.getElementById('runCollectorOnce').addEventListener('click', () => {
+            this.runCollectorOnce();
+        });
+
         document.getElementById('stopCollector').addEventListener('click', () => {
             this.stopCollector();
         });
@@ -248,15 +258,58 @@ class NetworkWatch {
         }
     }
 
+    async toggleCollectorMode() {
+        try {
+            const response = await fetch('/api/collector/mode', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ manual_mode: !this.collectorState.manual_mode })
+            });
+            const data = await response.json();
+            if (!response.ok) {
+                throw new Error(data.error || 'Failed to update collector mode');
+            }
+            this.collectorState = data;
+            this.updateCollectorControls();
+        } catch (error) {
+            console.error('Error updating collector mode:', error);
+            alert('Failed to update collector mode');
+        }
+    }
+
+    async runCollectorOnce() {
+        try {
+            const runButton = document.getElementById('runCollectorOnce');
+            runButton.disabled = true;
+            runButton.textContent = '⏳ Run Requested';
+
+            const response = await fetch('/api/collector/run_once', { method: 'POST' });
+            const data = await response.json();
+            if (!response.ok) {
+                throw new Error(data.error || 'Failed to request manual command run');
+            }
+            this.collectorState = data;
+            this.updateCollectorControls();
+        } catch (error) {
+            console.error('Error requesting manual command run:', error);
+            alert('Failed to request manual command run');
+            this.updateCollectorControls();
+        }
+    }
+
     updateCollectorControls(hasError = false) {
         const statusElement = document.getElementById('collectorStatus');
         const toggleButton = document.getElementById('toggleCollectorCommands');
+        const modeButton = document.getElementById('toggleCollectorMode');
+        const runButton = document.getElementById('runCollectorOnce');
         const stopButton = document.getElementById('stopCollector');
-        statusElement.classList.remove('status-unknown', 'status-paused', 'status-running', 'status-stopped');
+        statusElement.classList.remove('status-unknown', 'status-paused', 'status-running', 'status-stopped', 'status-manual');
 
         if (hasError) {
             statusElement.textContent = 'Collector: Unknown';
             statusElement.classList.add('status-unknown');
+            modeButton.disabled = true;
+            runButton.style.display = 'none';
             return;
         }
         const status = this.collectorState.status || 'unknown';
@@ -265,6 +318,9 @@ class NetworkWatch {
             statusElement.textContent = 'Collector: Stopped';
             statusElement.classList.add('status-stopped');
             toggleButton.disabled = true;
+            modeButton.disabled = true;
+            runButton.disabled = true;
+            runButton.style.display = 'none';
             stopButton.disabled = true;
             toggleButton.textContent = '⏹ Collector Stopped';
             return;
@@ -280,7 +336,25 @@ class NetworkWatch {
             toggleButton.textContent = '⏸ Pause Commands';
         }
 
+        if (!this.collectorState.commands_paused && this.collectorState.manual_mode) {
+            statusElement.textContent = this.collectorState.manual_run_requested
+                ? 'Collector: Manual Run Pending'
+                : 'Collector: Manual';
+            statusElement.classList.remove('status-running', 'status-paused');
+            statusElement.classList.add('status-manual');
+        }
+
+        modeButton.textContent = this.collectorState.manual_mode
+            ? 'Manual Mode: On'
+            : 'Manual Mode: Off';
+        runButton.style.display = this.collectorState.manual_mode ? 'inline-flex' : 'none';
+        runButton.disabled = Boolean(this.collectorState.commands_paused || this.collectorState.manual_run_requested);
+        runButton.textContent = this.collectorState.manual_run_requested
+            ? '⏳ Run Requested'
+            : '▶ Run Commands Now';
+
         toggleButton.disabled = false;
+        modeButton.disabled = false;
         stopButton.disabled = false;
     }
 

--- a/src/nw_watch/webapp/static/style.css
+++ b/src/nw_watch/webapp/static/style.css
@@ -185,9 +185,18 @@ header h1 {
     border-color: rgba(255, 193, 7, 0.9);
 }
 
+.collector-status.status-manual {
+    color: #e3f2fd;
+    border-color: rgba(33, 150, 243, 0.9);
+}
+
 .collector-status.status-stopped {
     color: #ffebee;
     border-color: rgba(220, 53, 69, 0.9);
+}
+
+.collector-manual-run {
+    display: none;
 }
 
 .collector-status.status-unknown {

--- a/src/nw_watch/webapp/templates/index.html
+++ b/src/nw_watch/webapp/templates/index.html
@@ -30,6 +30,8 @@ Review required for correctness, security, and licensing.
             </div>
             <div class="collector-controls">
                 <span id="collectorStatus" class="collector-status status-unknown">Collector: Unknown</span>
+                <button id="toggleCollectorMode" class="btn">Manual Mode: Off</button>
+                <button id="runCollectorOnce" class="btn btn-warning collector-manual-run">▶ Run Commands Now</button>
                 <button id="toggleCollectorCommands" class="btn btn-warning">⏸ Pause Commands</button>
                 <button id="stopCollector" class="btn btn-danger">⏹ Stop Collector</button>
             </div>

--- a/tests/test_collector_control_integration.py
+++ b/tests/test_collector_control_integration.py
@@ -13,8 +13,6 @@
 
 import pytest
 from fastapi.testclient import TestClient
-from pathlib import Path
-import os
 
 
 @pytest.fixture(autouse=True)
@@ -42,6 +40,8 @@ def test_pause_button_updates_control_state(client, control_dir):
     assert response.status_code == 200
     data = response.json()
     assert data["commands_paused"] is False
+    assert data["manual_mode"] is False
+    assert data["manual_run_requested"] is False
     assert data["status"] == "running"
 
     # Click pause button (POST to pause endpoint)
@@ -103,18 +103,43 @@ def test_stop_button_updates_control_state(client, control_dir):
     assert state["shutdown_requested"] is True
 
 
+def test_manual_mode_buttons_update_control_state(client, control_dir):
+    """Test that manual mode and run buttons update control state."""
+    from nw_watch.shared.control_state import read_control_state
+
+    response = client.post("/api/collector/mode", json={"manual_mode": True})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["manual_mode"] is True
+    assert data["manual_run_requested"] is False
+    assert data["status"] == "manual"
+
+    state = read_control_state()
+    assert state["manual_mode"] is True
+    assert state["manual_run_requested"] is False
+
+    response = client.post("/api/collector/run_once")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["manual_run_requested"] is True
+
+    state = read_control_state()
+    assert state["manual_mode"] is True
+    assert state["manual_run_requested"] is True
+
+
 def test_collector_would_respect_pause_state(control_dir):
     """Test that collector logic would respect pause state."""
     from nw_watch.shared.control_state import update_control_state, read_control_state
 
     # Simulate collector checking state while running
-    state = update_control_state({"commands_paused": False})
+    update_control_state({"commands_paused": False})
     current = read_control_state()
     assert current["commands_paused"] is False
     # Collector would continue executing commands
 
     # Simulate webapp pausing via button
-    state = update_control_state({"commands_paused": True})
+    update_control_state({"commands_paused": True})
 
     # Simulate collector checking state on next poll
     current = read_control_state()
@@ -127,7 +152,7 @@ def test_collector_would_respect_stop_state(control_dir):
     from nw_watch.shared.control_state import update_control_state, read_control_state
 
     # Simulate webapp stopping via button
-    state = update_control_state({"shutdown_requested": True, "commands_paused": True})
+    update_control_state({"shutdown_requested": True, "commands_paused": True})
 
     # Simulate collector checking state
     current = read_control_state()

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -380,6 +380,8 @@ def test_collector_status_default(client):
 
     data = response.json()
     assert data["commands_paused"] is False
+    assert data["manual_mode"] is False
+    assert data["manual_run_requested"] is False
     assert data["shutdown_requested"] is False
     assert data["status"] == "running"
 
@@ -411,6 +413,36 @@ def test_collector_stop(client):
     assert data["status"] == "stopped"
 
     response = client.post("/api/collector/pause")
+    assert response.status_code == 409
+
+
+def test_collector_manual_mode_and_run_once(client):
+    """Test manual command execution mode controls."""
+    response = client.post("/api/collector/mode", json={"manual_mode": True})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["manual_mode"] is True
+    assert data["manual_run_requested"] is False
+    assert data["status"] == "manual"
+
+    response = client.post("/api/collector/run_once")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["manual_mode"] is True
+    assert data["manual_run_requested"] is True
+    assert data["status"] == "manual"
+
+    response = client.post("/api/collector/mode", json={"manual_mode": False})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["manual_mode"] is False
+    assert data["manual_run_requested"] is False
+    assert data["status"] == "running"
+
+
+def test_collector_run_once_requires_manual_mode(client):
+    """Test manual run requests are rejected outside manual mode."""
+    response = client.post("/api/collector/run_once")
     assert response.status_code == 409
 
 


### PR DESCRIPTION
## Summary
- Add collector manual mode state and API endpoints for toggling automatic/manual command collection.
- Add a Web GUI manual mode toggle and show a Run Commands Now button only in manual mode.
- Update collector behavior so manual mode waits for a one-shot run request, then clears it after accepting the request.
- Update tests and collector control documentation/specification endpoint lists.

## Rationale
Command collection was automatic-only. Operators can now switch command collection to manual mode from the Web GUI and trigger a one-time command collection cycle on demand while ping monitoring continues.

## Validation
- `PYTHONPATH=src pytest -q` -> 256 passed, 2 skipped
- `PYTHONPATH=src pytest tests/test_webapp.py tests/test_collector_control_integration.py tests/test_collector.py -q` -> 43 passed
- `PYTHONPATH=src python -m black --check src/nw_watch/shared/control_state.py src/nw_watch/collector/main.py src/nw_watch/webapp/main.py tests/test_webapp.py tests/test_collector_control_integration.py` -> passed
- `PYTHONPATH=src python -m flake8 --extend-ignore=E501 src/nw_watch/shared/control_state.py src/nw_watch/collector/main.py src/nw_watch/webapp/main.py tests/test_webapp.py tests/test_collector_control_integration.py` -> passed
- `PYTHONPATH=src python -m compileall src/nw_watch` -> passed

## Docs
Updated collector controls docs and specification endpoint lists in English and Japanese.

## Compatibility
Existing control state files are normalized with default `manual_mode: false` and `manual_run_requested: false`, so existing automatic behavior is preserved.

## LLM Involvement
Files modified with LLM assistance: `src/nw_watch/shared/control_state.py`, `src/nw_watch/collector/main.py`, `src/nw_watch/webapp/main.py`, `src/nw_watch/webapp/static/app.js`, `src/nw_watch/webapp/static/style.css`, `src/nw_watch/webapp/templates/index.html`, `tests/test_webapp.py`, `tests/test_collector_control_integration.py`, `docs/collector-controls.md`, `docs/collector-controls.ja.md`, `docs/specification.md`, `docs/specification.ja.md`. Human review performed by checking diff scope, running tests, formatting, lint checks, and compileall locally.

## Checklist
- [x] License header added to new files and top-level LICENSE present
- [x] LLM attribution added to modified/generated files
- [x] Linting completed — command: `PYTHONPATH=src python -m flake8 --extend-ignore=E501 src/nw_watch/shared/control_state.py src/nw_watch/collector/main.py src/nw_watch/webapp/main.py tests/test_webapp.py tests/test_collector_control_integration.py`
- [x] Tests pass locally — command: `PYTHONPATH=src pytest -q`
- [ ] Static analysis/type checks pass — not run; no configured mypy invocation was run for this change
- [x] Formatting applied — command: `PYTHONPATH=src python -m black --check src/nw_watch/shared/control_state.py src/nw_watch/collector/main.py src/nw_watch/webapp/main.py tests/test_webapp.py tests/test_collector_control_integration.py`
- [ ] Pre-commit hooks pass — not run; no pre-commit config/hook run was performed
- [ ] CI build passes — pending GitHub CI
- [x] No merge conflicts with base branch
- [x] Changelog/versioning updated (if applicable) — not applicable
- [x] Documentation updated (README, docs/, API docs)
- [x] Examples/quick-start updated (if applicable) — not applicable
- [x] Commit messages follow repository conventions
- [x] PR description includes: issue link, summary, rationale, tests, docs, migration notes
- [x] PR description explicitly lists LLM-modified files and human review notes
