### PR TITLE
[codex] Add fixed origin snapshots for history diffs

### DIFF
--- a/docs/webui-screenshots.ja.md
+++ b/docs/webui-screenshots.ja.md
@@ -118,14 +118,21 @@ Network Watch Webインターフェースは、リアルタイムのネットワ
 
 インターフェースは、ネットワークデバイスの状態変化を識別するための2種類の差分比較を提供します。
 
-### 5.1 履歴差分（前回 vs 最新）
+### 5.1 履歴差分（前回またはSnapshot vs 最新）
 
-同じデバイスとコマンドの最新2回の実行を比較します。
+同じデバイスとコマンドの最新実行を、選択したOriginと比較します。
+初期状態のOriginは直前の実行です。必要に応じて固定Origin Snapshotを取得し、
+以降の最新データをそのSnapshotと比較できます。
 
 **機能**:
-- **ボタン**: "Show Previous vs Latest"（≥2回の実行が存在する場合に表示）
+- **ボタン**: "Show History Diff"（各デバイスの出力パネルに表示）
+- **Originモード切り替え**:
+  - "Previous": 最新実行と直前の実行を比較
+  - "Snapshot": 最新実行と取得済みのOrigin Snapshotを比較
+- **Snapshot取得**: "Capture Origin Snapshot" で現在の最新実行を固定Originとして保存
+- **Originステータス**: 現在のモード、Snapshot取得時刻、Originデータ時刻、最新データ時刻を表示
 - **比較ラベル**: 
-  - 左列: "Previous"（古い実行とタイムスタンプ）
+  - 左列: "Previous" または "Snapshot"（Origin実行）
   - 右列: "Latest"（新しい実行とタイムスタンプ）
 - **カラーコーディング**:
   - 🟩 緑背景: 最新実行で追加された行

--- a/docs/webui-screenshots.md
+++ b/docs/webui-screenshots.md
@@ -118,14 +118,21 @@ Each run entry displays:
 
 The interface provides two types of diff comparisons to identify changes in network device states.
 
-### 5.1 Historical Diff (Previous vs Latest)
+### 5.1 Historical Diff (Previous or Snapshot vs Latest)
 
-Compares the two most recent runs for the same device and command.
+Compares the latest run for the same device and command against a selectable origin.
+The default origin is the previous run. Users can also capture a fixed origin
+snapshot and keep comparing newer data against that snapshot.
 
 **Features**:
-- **Button**: "Show Previous vs Latest" (appears when ≥2 runs exist)
+- **Button**: "Show History Diff" (appears in each device output panel)
+- **Origin Mode Toggle**:
+  - "Previous": compares the latest run with the immediately preceding run
+  - "Snapshot": compares the latest run with the captured origin snapshot
+- **Snapshot Capture**: "Capture Origin Snapshot" stores the current latest run as the fixed origin
+- **Origin Status**: shows the active mode, snapshot capture time, origin data time, and latest data time
 - **Comparison Labels**: 
-  - Left column: "Previous" (older run with timestamp)
+  - Left column: "Previous" or "Snapshot" (origin run)
   - Right column: "Latest" (newer run with timestamp)
 - **Color Coding**:
   - 🟩 Green background: Lines added in latest run

--- a/src/nw_watch/webapp/main.py
+++ b/src/nw_watch/webapp/main.py
@@ -19,7 +19,7 @@ import time
 from contextlib import asynccontextmanager
 from functools import lru_cache
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 from yaml import YAMLError
 
@@ -49,6 +49,7 @@ logger = logging.getLogger(__name__)
 _background_task = None
 _last_db_mtime = None
 _db_mtime_lock = asyncio.Lock()
+_history_diff_snapshots: Dict[Tuple[str, str], Dict[str, Any]] = {}
 
 # Constants for database monitoring
 DATABASE_CHECK_INTERVAL_DIVISOR = 2  # Monitor at half the collection interval
@@ -179,6 +180,43 @@ def get_db(history_size: int) -> Optional[Database]:
     if not DATABASE_PATH.exists():
         return None
     return Database(str(DATABASE_PATH), history_size=history_size)
+
+
+def get_history_snapshot_key(command: str, device: str) -> Tuple[str, str]:
+    """Return the stable key for a history diff snapshot."""
+    return command, device.strip()
+
+
+def build_history_diff_response(
+    origin_run: Dict[str, Any],
+    latest_run: Dict[str, Any],
+    *,
+    origin_label: str,
+    origin_mode: str,
+    snapshot_captured_at: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Build a history diff payload from a selected origin and latest run."""
+    origin_text = origin_run.get("output_text", "")
+    latest_text = latest_run.get("output_text", "")
+    diff = generate_side_by_side_diff(
+        origin_text, latest_text, label_a=origin_label, label_b="Latest"
+    )
+
+    response: Dict[str, Any] = {
+        "diff": diff,
+        "diff_format": "html",
+        "has_diff": origin_text != latest_text,
+        "origin_mode": origin_mode,
+        "origin_label": origin_label,
+        "origin_ts": origin_run["ts_epoch"],
+        "latest_ts": latest_run["ts_epoch"],
+        "snapshot_available": origin_mode == "snapshot",
+    }
+    if origin_mode == "previous":
+        response["previous_ts"] = origin_run["ts_epoch"]
+    if snapshot_captured_at is not None:
+        response["snapshot_captured_at"] = snapshot_captured_at
+    return response
 
 
 def build_collector_status() -> Dict[str, object]:
@@ -361,13 +399,54 @@ async def get_runs_side_by_side(command: str):
 
 
 @app.get("/api/diff/history")
-async def get_history_diff(command: str, device: str):
-    """Get diff between latest and previous run."""
+async def get_history_diff(command: str, device: str, origin_mode: str = "previous"):
+    """Get diff between latest and the selected history origin."""
     db = get_db(resolve_history_size())
     if not db:
         return JSONResponse({"error": "Database not available"}, status_code=503)
 
     try:
+        if origin_mode not in {"previous", "snapshot"}:
+            return JSONResponse({"error": "Invalid origin_mode"}, status_code=400)
+
+        if origin_mode == "snapshot":
+            latest = db.get_latest_run(device, command, include_filtered=False)
+            if not latest:
+                return JSONResponse(
+                    {
+                        "diff": "Latest data is not available",
+                        "has_diff": False,
+                        "diff_format": "text",
+                        "origin_mode": "snapshot",
+                        "snapshot_available": False,
+                    }
+                )
+
+            snapshot = _history_diff_snapshots.get(
+                get_history_snapshot_key(command, device)
+            )
+            if not snapshot:
+                return JSONResponse(
+                    {
+                        "diff": "Snapshot has not been captured",
+                        "has_diff": False,
+                        "diff_format": "text",
+                        "origin_mode": "snapshot",
+                        "latest_ts": latest["ts_epoch"],
+                        "snapshot_available": False,
+                    }
+                )
+
+            return JSONResponse(
+                build_history_diff_response(
+                    snapshot["run"],
+                    latest,
+                    origin_label="Snapshot",
+                    origin_mode="snapshot",
+                    snapshot_captured_at=snapshot["captured_at"],
+                )
+            )
+
         runs = db.get_latest_runs(device, command, limit=2, include_filtered=False)
 
         if len(runs) < 2:
@@ -376,30 +455,88 @@ async def get_history_diff(command: str, device: str):
                     "diff": "Not enough history for comparison",
                     "has_diff": False,
                     "diff_format": "text",
+                    "origin_mode": "previous",
+                    "snapshot_available": False,
                 }
             )
 
         latest = runs[0]
         previous = runs[1]
 
-        previous_text = previous.get("output_text", "")
-        latest_text = latest.get("output_text", "")
-        diff = generate_side_by_side_diff(
-            previous_text, latest_text, label_a="Previous", label_b="Latest"
+        return JSONResponse(
+            build_history_diff_response(
+                previous,
+                latest,
+                origin_label="Previous",
+                origin_mode="previous",
+            )
         )
-        has_diff = previous_text != latest_text
+    finally:
+        db.close()
 
+
+@app.post("/api/diff/snapshot")
+async def capture_history_diff_snapshot(command: str, device: str):
+    """Capture the latest run as the fixed origin for history diff."""
+    db = get_db(resolve_history_size())
+    if not db:
+        return JSONResponse({"error": "Database not available"}, status_code=503)
+
+    try:
+        latest = db.get_latest_run(device, command, include_filtered=False)
+        if not latest:
+            return JSONResponse(
+                {"error": "Latest data is not available"}, status_code=404
+            )
+
+        captured_at = int(time.time())
+        snapshot = {
+            "captured_at": captured_at,
+            "run": dict(latest),
+        }
+        _history_diff_snapshots[get_history_snapshot_key(command, device)] = snapshot
         return JSONResponse(
             {
-                "diff": diff,
-                "diff_format": "html",
-                "has_diff": has_diff,
+                "snapshot_available": True,
+                "captured_at": captured_at,
+                "origin_ts": latest["ts_epoch"],
                 "latest_ts": latest["ts_epoch"],
-                "previous_ts": previous["ts_epoch"],
             }
         )
     finally:
         db.close()
+
+
+@app.get("/api/diff/snapshot/status")
+async def get_history_diff_snapshot_status(command: str, device: str):
+    """Get fixed history diff snapshot status for a device and command."""
+    snapshot = _history_diff_snapshots.get(get_history_snapshot_key(command, device))
+
+    db = get_db(resolve_history_size())
+    latest_ts = None
+    if db:
+        try:
+            latest = db.get_latest_run(device, command, include_filtered=False)
+            latest_ts = latest["ts_epoch"] if latest else None
+        finally:
+            db.close()
+
+    if not snapshot:
+        return JSONResponse(
+            {
+                "snapshot_available": False,
+                "latest_ts": latest_ts,
+            }
+        )
+
+    return JSONResponse(
+        {
+            "snapshot_available": True,
+            "captured_at": snapshot["captured_at"],
+            "origin_ts": snapshot["run"]["ts_epoch"],
+            "latest_ts": latest_ts,
+        }
+    )
 
 
 @app.get("/api/diff/devices")
@@ -475,7 +612,7 @@ async def get_ping_status(window_seconds: int = 60):
                         avg_rtt = sum(rtts) / len(rtts)
                 # Build timeline (oldest -> newest)
                 samples_by_ts = {s["ts_epoch"]: s for s in samples}
-                timeline = []
+                timeline: list[Optional[bool]] = []
                 for offset in range(window_seconds - 1, -1, -1):
                     ts = current_ts - offset
                     sample = samples_by_ts.get(ts)
@@ -683,6 +820,7 @@ async def export_diff(
     device_a: Optional[str] = None,
     device_b: Optional[str] = None,
     format: str = "html",
+    origin_mode: str = "previous",
 ):
     """Export diff view.
 
@@ -698,25 +836,42 @@ async def export_diff(
         return JSONResponse({"error": "Database not available"}, status_code=503)
 
     try:
-        # Determine diff type
         if device and not device_a and not device_b:
-            # History diff
-            runs = db.get_latest_runs(device, command, limit=2, include_filtered=False)
+            if origin_mode not in {"previous", "snapshot"}:
+                return JSONResponse({"error": "Invalid origin_mode"}, status_code=400)
 
-            if len(runs) < 2:
+            latest = db.get_latest_run(device, command, include_filtered=False)
+            if not latest:
                 return JSONResponse(
-                    {"error": "Not enough history for comparison"}, status_code=404
+                    {"error": "Latest data is not available"}, status_code=404
                 )
 
-            latest = runs[0]
-            previous = runs[1]
+            if origin_mode == "snapshot":
+                snapshot = _history_diff_snapshots.get(
+                    get_history_snapshot_key(command, device)
+                )
+                if not snapshot:
+                    return JSONResponse(
+                        {"error": "Snapshot has not been captured"}, status_code=404
+                    )
+                origin_run = snapshot["run"]
+                label_a = "Snapshot"
+            else:
+                runs = db.get_latest_runs(
+                    device, command, limit=2, include_filtered=False
+                )
+                if len(runs) < 2:
+                    return JSONResponse(
+                        {"error": "Not enough history for comparison"}, status_code=404
+                    )
+                origin_run = runs[1]
+                label_a = "Previous"
 
-            previous_text = previous.get("output_text", "")
+            previous_text = origin_run.get("output_text", "")
             latest_text = latest.get("output_text", "")
             diff_html = generate_side_by_side_diff(
-                previous_text, latest_text, label_a="Previous", label_b="Latest"
+                previous_text, latest_text, label_a=label_a, label_b="Latest"
             )
-            label_a = "Previous"
             label_b = "Latest"
             filename_prefix = f"history_diff_{sanitize_filename(device)}_{sanitize_filename(command.replace(' ', '_'))}"
 

--- a/src/nw_watch/webapp/static/app.js
+++ b/src/nw_watch/webapp/static/app.js
@@ -50,6 +50,7 @@ class NetworkWatch {
         // Diff state preservation
         // Structure: { "command:device": { type: 'history'|'device', content: '...', format: 'html'|'text', otherDevice: '...' } }
         this.diffStates = {};
+        this.historyDiffModes = {};
         this.DIFF_PLACEHOLDER_TEXT = 'Click a button above to view diff';
         this.sideBySideOutputHeight = this.loadSideBySideOutputHeight();
         
@@ -866,9 +867,32 @@ class NetworkWatch {
         
         // History diff button
         const historyBtn = document.createElement('button');
-        historyBtn.textContent = 'Show Previous vs Latest';
+        historyBtn.textContent = 'Show History Diff';
         historyBtn.addEventListener('click', () => this.showHistoryDiff(command, device));
         controls.appendChild(historyBtn);
+
+        const previousModeBtn = document.createElement('button');
+        previousModeBtn.className = 'diff-mode-btn active';
+        previousModeBtn.id = `diff-mode-previous-${device}`;
+        previousModeBtn.textContent = 'Previous';
+        previousModeBtn.addEventListener('click', () => {
+            this.setHistoryDiffMode(command, device, 'previous');
+        });
+        controls.appendChild(previousModeBtn);
+
+        const snapshotModeBtn = document.createElement('button');
+        snapshotModeBtn.className = 'diff-mode-btn';
+        snapshotModeBtn.id = `diff-mode-snapshot-${device}`;
+        snapshotModeBtn.textContent = 'Snapshot';
+        snapshotModeBtn.addEventListener('click', () => {
+            this.setHistoryDiffMode(command, device, 'snapshot');
+        });
+        controls.appendChild(snapshotModeBtn);
+
+        const snapshotBtn = document.createElement('button');
+        snapshotBtn.textContent = 'Capture Origin Snapshot';
+        snapshotBtn.addEventListener('click', () => this.captureHistorySnapshot(command, device));
+        controls.appendChild(snapshotBtn);
         
         // Device diff controls (if multiple devices)
         if (this.devices.length > 1) {
@@ -897,6 +921,13 @@ class NetworkWatch {
         }
         
         section.appendChild(controls);
+
+        const status = document.createElement('div');
+        status.className = 'diff-origin-status';
+        status.id = `diff-origin-status-${device}`;
+        status.textContent = 'Origin mode: Previous run';
+        section.appendChild(status);
+        this.loadHistorySnapshotStatus(command, device);
         
         // Diff output
         const diffOutput = document.createElement('div');
@@ -930,8 +961,9 @@ class NetworkWatch {
     
     async showHistoryDiff(command, device) {
         try {
+            const originMode = this.getHistoryDiffMode(command, device);
             const response = await fetch(
-                `/api/diff/history?command=${encodeURIComponent(command)}&device=${encodeURIComponent(device)}`
+                `/api/diff/history?command=${encodeURIComponent(command)}&device=${encodeURIComponent(device)}&origin_mode=${originMode}`
             );
             const data = await response.json();
             
@@ -942,6 +974,7 @@ class NetworkWatch {
                 'No differences found',
                 data.diff_format === 'html'
             );
+            this.renderHistoryDiffStatus(command, device, data);
             
             // Show export controls and store diff context
             const exportControls = document.getElementById(`diff-export-${device}`);
@@ -950,6 +983,7 @@ class NetworkWatch {
                 exportControls.dataset.diffType = 'history';
                 exportControls.dataset.command = command;
                 exportControls.dataset.device = device;
+                exportControls.dataset.originMode = originMode;
             }
             
             // Save the diff state immediately
@@ -958,12 +992,93 @@ class NetworkWatch {
                 type: 'history',
                 content: diffOutput.innerHTML,
                 isHtml: diffOutput.classList.contains('diff-output-html'),
+                originMode: originMode,
                 command: command,
                 device: device
             };
         } catch (error) {
             console.error('Error loading history diff:', error);
         }
+    }
+
+    getHistoryDiffMode(command, device) {
+        return this.historyDiffModes[`${command}:${device}`] || 'previous';
+    }
+
+    setHistoryDiffMode(command, device, mode) {
+        this.historyDiffModes[`${command}:${device}`] = mode;
+        this.updateHistoryModeControls(command, device);
+        this.renderHistoryDiffStatus(command, device);
+        this.showHistoryDiff(command, device);
+    }
+
+    updateHistoryModeControls(command, device) {
+        const mode = this.getHistoryDiffMode(command, device);
+        const previousBtn = document.getElementById(`diff-mode-previous-${device}`);
+        const snapshotBtn = document.getElementById(`diff-mode-snapshot-${device}`);
+        if (previousBtn) {
+            previousBtn.classList.toggle('active', mode === 'previous');
+        }
+        if (snapshotBtn) {
+            snapshotBtn.classList.toggle('active', mode === 'snapshot');
+        }
+    }
+
+    async captureHistorySnapshot(command, device) {
+        try {
+            const response = await fetch(
+                `/api/diff/snapshot?command=${encodeURIComponent(command)}&device=${encodeURIComponent(device)}`,
+                { method: 'POST' }
+            );
+            const data = await response.json();
+            if (!response.ok) {
+                throw new Error(data.error || 'Failed to capture snapshot');
+            }
+            this.historyDiffModes[`${command}:${device}`] = 'snapshot';
+            this.updateHistoryModeControls(command, device);
+            this.renderHistoryDiffStatus(command, device, data);
+            await this.showHistoryDiff(command, device);
+        } catch (error) {
+            console.error('Error capturing history snapshot:', error);
+            alert('Failed to capture origin snapshot');
+        }
+    }
+
+    async loadHistorySnapshotStatus(command, device) {
+        try {
+            const response = await fetch(
+                `/api/diff/snapshot/status?command=${encodeURIComponent(command)}&device=${encodeURIComponent(device)}`
+            );
+            const data = await response.json();
+            this.renderHistoryDiffStatus(command, device, data);
+        } catch (error) {
+            console.error('Error loading history snapshot status:', error);
+        }
+    }
+
+    renderHistoryDiffStatus(command, device, data = {}) {
+        const status = document.getElementById(`diff-origin-status-${device}`);
+        if (!status) return;
+
+        const mode = this.getHistoryDiffMode(command, device);
+        const modeLabel = mode === 'snapshot' ? 'Snapshot' : 'Previous run';
+        const details = [`Origin mode: ${modeLabel}`];
+
+        const snapshotCapturedAt = data.captured_at || data.snapshot_captured_at;
+        if (data.snapshot_available && snapshotCapturedAt) {
+            details.push(`Snapshot captured: ${this.formatTimestampJST(snapshotCapturedAt)}`);
+        } else if (mode === 'snapshot') {
+            details.push('Snapshot: not captured');
+        }
+
+        if (data.origin_ts) {
+            details.push(`Origin data: ${this.formatTimestampJST(data.origin_ts)}`);
+        }
+        if (data.latest_ts) {
+            details.push(`Latest data: ${this.formatTimestampJST(data.latest_ts)}`);
+        }
+
+        status.textContent = details.join(' | ');
     }
     
     async showDeviceDiff(command, deviceA, deviceB) {
@@ -1032,7 +1147,8 @@ class NetworkWatch {
         let url;
         
         if (diffType === 'history') {
-            url = `/api/export/diff?command=${encodeURIComponent(command)}&device=${encodeURIComponent(device)}&format=${format}`;
+            const originMode = exportControls.dataset.originMode || this.getHistoryDiffMode(command, device);
+            url = `/api/export/diff?command=${encodeURIComponent(command)}&device=${encodeURIComponent(device)}&format=${format}&origin_mode=${originMode}`;
         } else if (diffType === 'device') {
             const deviceA = exportControls.dataset.deviceA;
             const deviceB = exportControls.dataset.deviceB;
@@ -1060,6 +1176,8 @@ class NetworkWatch {
     }
 
     renderDiff(element, diffText, fallbackMessage, isHtml = false) {
+        element.classList.remove('diff-output-html');
+
         if (!diffText || diffText.length === 0) {
             element.textContent = fallbackMessage;
             return;
@@ -1141,6 +1259,7 @@ class NetworkWatch {
                     type: diffType,
                     content: diffOutputElement.innerHTML,
                     isHtml: diffOutputElement.classList.contains('diff-output-html'),
+                    originMode: exportControlsElement.dataset.originMode,
                     otherDevice: otherDevice,
                     command: command,
                     device: device
@@ -1181,6 +1300,11 @@ class NetworkWatch {
             exportControlsElement.dataset.diffType = state.type;
             exportControlsElement.dataset.command = state.command;
             exportControlsElement.dataset.device = state.device;
+            if (state.originMode) {
+                exportControlsElement.dataset.originMode = state.originMode;
+                this.historyDiffModes[stateKey] = state.originMode;
+                this.updateHistoryModeControls(command, device);
+            }
             if (state.otherDevice) {
                 exportControlsElement.dataset.deviceB = state.otherDevice;
             }

--- a/src/nw_watch/webapp/static/style.css
+++ b/src/nw_watch/webapp/static/style.css
@@ -462,6 +462,8 @@ header h1 {
 .diff-controls {
     margin-bottom: 15px;
     display: flex;
+    flex-wrap: wrap;
+    align-items: center;
     gap: 10px;
 }
 
@@ -479,6 +481,21 @@ header h1 {
     background-color: #5568d3;
 }
 
+.diff-controls .diff-mode-btn {
+    background-color: var(--tab-bg);
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
+}
+
+.diff-controls .diff-mode-btn:hover {
+    background-color: var(--tab-hover-bg);
+}
+
+.diff-controls .diff-mode-btn.active {
+    background-color: var(--tab-active-bg);
+    color: white;
+}
+
 .diff-controls select {
     padding: 8px;
     border: 1px solid var(--border-color);
@@ -487,6 +504,18 @@ header h1 {
     background-color: var(--bg-secondary);
     color: var(--text-primary);
     transition: background-color 0.3s, border-color 0.3s, color 0.3s;
+}
+
+.diff-origin-status {
+    display: inline-block;
+    margin-bottom: 10px;
+    padding: 8px 10px;
+    background-color: var(--bg-secondary);
+    color: var(--text-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    font-size: 12px;
+    line-height: 1.4;
 }
 
 .diff-output {

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -88,11 +88,15 @@ def client(test_db):
 
     shutil.copy2(test_db, current_db)
 
-    from nw_watch.webapp.main import app
+    from nw_watch.webapp.main import _history_diff_snapshots, app
+
+    _history_diff_snapshots.clear()
 
     client = TestClient(app)
 
     yield client
+
+    _history_diff_snapshots.clear()
 
     # Cleanup
     if current_db.exists():
@@ -303,6 +307,85 @@ def test_get_history_diff(client):
     data = response.json()
     assert "diff" in data
     assert "has_diff" in data
+    assert data["origin_mode"] == "previous"
+
+
+def test_get_history_diff_snapshot_without_capture(client):
+    """Test getting snapshot diff before a snapshot exists."""
+    response = client.get(
+        "/api/diff/history?command=show%20version&device=DeviceA&origin_mode=snapshot"
+    )
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["origin_mode"] == "snapshot"
+    assert data["snapshot_available"] is False
+    assert data["diff_format"] == "text"
+
+
+def test_capture_history_diff_snapshot(client):
+    """Test capturing a fixed origin snapshot for history diff."""
+    response = client.post("/api/diff/snapshot?command=show%20version&device=DeviceA")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["snapshot_available"] is True
+    assert data["origin_ts"] == 1000000
+    assert data["latest_ts"] == 1000000
+
+    status_response = client.get(
+        "/api/diff/snapshot/status?command=show%20version&device=DeviceA"
+    )
+    assert status_response.status_code == 200
+    status = status_response.json()
+    assert status["snapshot_available"] is True
+    assert status["origin_ts"] == 1000000
+
+
+def test_get_history_diff_uses_fixed_snapshot_origin(client):
+    """Test snapshot diff keeps the captured origin as newer runs arrive."""
+    response = client.post("/api/diff/snapshot?command=show%20version&device=DeviceA")
+    assert response.status_code == 200
+
+    db = Database("data/current.sqlite3")
+    db.insert_run(
+        device_name="DeviceA",
+        command_text="show version",
+        ts_epoch=1000002,
+        output_text="Version 1.1",
+        ok=True,
+        duration_ms=100.0,
+        original_line_count=10,
+    )
+    db.insert_run(
+        device_name="DeviceA",
+        command_text="show version",
+        ts_epoch=1000003,
+        output_text="Version 1.2",
+        ok=True,
+        duration_ms=100.0,
+        original_line_count=10,
+    )
+    db.close()
+
+    snapshot_response = client.get(
+        "/api/diff/history?command=show%20version&device=DeviceA&origin_mode=snapshot"
+    )
+    previous_response = client.get(
+        "/api/diff/history?command=show%20version&device=DeviceA"
+    )
+
+    assert snapshot_response.status_code == 200
+    assert previous_response.status_code == 200
+
+    snapshot = snapshot_response.json()
+    previous = previous_response.json()
+    assert snapshot["origin_mode"] == "snapshot"
+    assert snapshot["origin_ts"] == 1000000
+    assert snapshot["latest_ts"] == 1000003
+    assert snapshot["snapshot_available"] is True
+    assert previous["origin_mode"] == "previous"
+    assert previous["origin_ts"] == 1000002
 
 
 def test_get_device_diff(client):


### PR DESCRIPTION
## Summary
- Add a selectable history diff origin mode: previous run or fixed snapshot.
- Add APIs to capture and inspect per-device/per-command origin snapshots.
- Add UI controls and status text for snapshot capture time, origin data time, and latest data time.
- Update Web UI documentation and API tests.

## Rationale
History diff previously always compared the latest run with the immediately preceding run. Operators need to pin a known-good origin and compare later collected data against that fixed point while retaining the existing previous-vs-latest workflow.

## Validation
- `PYTHONPATH=src python -m pytest -q` -> 260 passed, 2 skipped
- `PYTHONPATH=src python -m pytest tests/test_webapp.py -q` -> 33 passed
- `node --check src/nw_watch/webapp/static/app.js`
- `python -m black --check src/nw_watch/webapp/main.py tests/test_webapp.py`
- `PYTHONPATH=src python -m flake8 --extend-ignore=E501 src/nw_watch/webapp/main.py tests/test_webapp.py`
- `PYTHONPATH=src python -m mypy src/nw_watch/webapp/main.py`
- `git diff --check`
- Browser smoke test on local FastAPI app: verified Previous mode, Snapshot capture, Snapshot mode status, and fixed-origin diff after newer data arrived.

## Documentation
- Updated `docs/webui-screenshots.md` and `docs/webui-screenshots.ja.md`.

## Backward Compatibility
- Existing `/api/diff/history` callers continue to use previous-vs-latest comparison by default.
- Snapshot state is process-local and is reset when the Web app process restarts.

## LLM Involvement
Files created/modified by LLM assistance:
- `src/nw_watch/webapp/main.py`
- `src/nw_watch/webapp/static/app.js`
- `src/nw_watch/webapp/static/style.css`
- `tests/test_webapp.py`
- `docs/webui-screenshots.md`
- `docs/webui-screenshots.ja.md`

Human review notes: pending maintainer review. Local validation and browser smoke testing were performed before opening this draft PR.

## Checklist
- [x] License header added to new files and top-level LICENSE present
- [x] LLM attribution added to modified/generated files
- [x] Linting completed — score: repo flake8 target passes with existing E501 ignored (command: `PYTHONPATH=src python -m flake8 --extend-ignore=E501 src/nw_watch/webapp/main.py tests/test_webapp.py`)
- [x] Tests pass locally (command: `PYTHONPATH=src python -m pytest -q`)
- [x] Static analysis/type checks pass (command: `PYTHONPATH=src python -m mypy src/nw_watch/webapp/main.py`)
- [x] Formatting applied (command: `python -m black --check src/nw_watch/webapp/main.py tests/test_webapp.py`)
- [x] Pre-commit hooks pass (no executable pre-commit hook present)
- [ ] CI build passes
- [ ] No merge conflicts with base branch
- [x] Changelog/versioning updated (not applicable)
- [x] Documentation updated (README, docs/, API docs)
- [x] Examples/quick-start updated (not applicable)
- [x] Commit messages follow repository conventions
- [x] PR description includes: issue link, summary, rationale, tests, docs, migration notes
- [x] PR description explicitly lists LLM-modified files and human review notes
