### PR TITLE
[codex] add standalone ping targets

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -16,6 +16,7 @@ Review required for correctness, security, and licensing.
 English: [README.md](README.md)
 
 nw-watch は、ネットワーク機器に SSH で接続して CLI 出力と ping 結果を収集し、SQLite に保存、FastAPI 製 Web UI でリアルタイム表示と差分比較を行うツールです。
+SSH コマンド実行対象とは別に、最大 3 件の独立した IP/ホストも ping 監視できます。
 
 ## インストール
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Review required for correctness, security, and licensing.
 Japanese: [README.ja.md](README.ja.md)
 
 nw-watch collects CLI outputs and ping health from network devices over SSH, stores data in SQLite, and serves real-time monitoring and diff views through a FastAPI web UI.
+It can also monitor up to three standalone IPs/hosts independently of SSH command devices.
 
 ## Installation
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,3 +1,15 @@
+# Copyright 2026 icecake0141
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
 # Network Watch Configuration Example
 
 # Core intervals and history
@@ -6,6 +18,11 @@ ping_interval_seconds: 1         # Ping interval
 ping_window_seconds: 60          # Window (seconds) for ping tiles
 history_size: 10                 # Max runs per device/command to keep
 max_output_lines: 500            # Truncate outputs after filtering
+
+# Standalone ping targets independent of SSH command devices (optional, max: 3)
+ping_targets:
+  - name: "GatewayVIP"
+    host: "192.168.1.254"
 
 # Collector settings (optional)
 collector:

--- a/docs/specification.ja.md
+++ b/docs/specification.ja.md
@@ -26,6 +26,7 @@ English: [specification.md](specification.md)
 - グローバル実行間隔: `interval_seconds`
 - コマンド個別上書き: `commands[].interval_seconds`（許容範囲 5-60 秒）
 - ping 間隔: `ping_interval_seconds`
+- 独立 ping 監視対象: `ping_targets[]`（任意、最大 3 件）
 - 履歴保持: `history_size`（デバイス/コマンドごとに最新 N 件）
 - フィルター:
 - `global_filters.line_exclude_substrings` は一致行を削除
@@ -42,6 +43,8 @@ English: [specification.md](specification.md)
 主な任意ブロック:
 
 - `collector.max_workers`
+- `ping_targets[].name`
+- `ping_targets[].host`
 - `websocket.enabled`
 - `websocket.ping_interval`
 - `ssh.persistent_connections`

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -26,6 +26,7 @@ Japanese: [specification.ja.md](specification.ja.md)
 - Global command interval: `interval_seconds`.
 - Per-command override: `commands[].interval_seconds` (validated range: 5-60 seconds).
 - Ping interval: `ping_interval_seconds`.
+- Standalone ping targets: `ping_targets[]` (optional, max 3 entries).
 - Command history retention: `history_size` latest runs per device/command.
 - Filtering:
 - `global_filters.line_exclude_substrings` removes matching lines.
@@ -42,6 +43,8 @@ Main required blocks in `config.yaml`:
 Main optional blocks:
 
 - `collector.max_workers`
+- `ping_targets[].name`
+- `ping_targets[].host`
 - `websocket.enabled`
 - `websocket.ping_interval`
 - `ssh.persistent_connections`

--- a/src/nw_watch/collector/main.py
+++ b/src/nw_watch/collector/main.py
@@ -14,6 +14,7 @@
 import argparse
 import asyncio
 import logging
+import re
 import shutil
 import signal
 import subprocess
@@ -22,7 +23,7 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from netmiko import ConnectHandler
 from netmiko.exceptions import NetmikoTimeoutException, NetmikoAuthenticationException
@@ -40,6 +41,7 @@ logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger(__name__)
+PING_HOST_PATTERN = re.compile(r"^[a-zA-Z0-9._:-]+$")
 
 
 def classify_command_error(error: Exception) -> str:
@@ -79,6 +81,70 @@ def classify_command_error(error: Exception) -> str:
         return "Authentication Failed"
 
     return error_text or "Command Failed"
+
+
+def ping_target(db: Database, target_name: str, ping_host: str) -> None:
+    """Ping a host and store the result under the target name."""
+    ts_epoch = int(time.time())
+
+    if not PING_HOST_PATTERN.match(ping_host):
+        logger.error("Invalid ping host format for %s: %s", target_name, ping_host)
+        db.insert_ping_sample(
+            device_name=target_name,
+            ts_epoch=ts_epoch,
+            ok=False,
+            error_message="Invalid ping_host format",
+        )
+        return
+
+    try:
+        result = subprocess.run(
+            ["ping", "-c", "1", "-W", "1", ping_host],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+
+        if result.returncode == 0:
+            rtt_ms = None
+            for line in result.stdout.splitlines():
+                if "time=" in line:
+                    try:
+                        parts = line.split("time=")[1].split()[0]
+                        rtt_ms = float(parts)
+                        break
+                    except (IndexError, ValueError):
+                        pass
+
+            db.insert_ping_sample(
+                device_name=target_name,
+                ts_epoch=ts_epoch,
+                ok=True,
+                rtt_ms=rtt_ms,
+            )
+        else:
+            stderr = result.stderr.strip()
+            stdout = result.stdout.strip()
+            detail = stderr or stdout
+            if detail:
+                logger.debug(
+                    "Ping failed for %s (%s): %s", target_name, ping_host, detail
+                )
+            db.insert_ping_sample(
+                device_name=target_name,
+                ts_epoch=ts_epoch,
+                ok=False,
+                error_message="Not Responding",
+            )
+
+    except Exception as e:
+        logger.debug("Ping check failed for %s: %s", target_name, e)
+        db.insert_ping_sample(
+            device_name=target_name,
+            ts_epoch=ts_epoch,
+            ok=False,
+            error_message="Not Responding",
+        )
 
 
 class DeviceCollector:
@@ -307,76 +373,8 @@ class DeviceCollector:
 
     def ping_device(self, db: Database) -> None:
         """Ping the device and store result."""
-        ts_epoch = int(time.time())
         ping_host = self.device_config.get("ping_host", self.device_config["host"])
-
-        # Validate ping_host to prevent command injection
-        # Allow only valid hostnames/IPs (alphanumeric, dots, hyphens, colons for IPv6)
-        import re
-
-        if not re.match(r"^[a-zA-Z0-9.\-:]+$", ping_host):
-            logger.error(f"Invalid ping_host format: {ping_host}")
-            db.insert_ping_sample(
-                device_name=self.device_name,
-                ts_epoch=ts_epoch,
-                ok=False,
-                error_message="Invalid ping_host format",
-            )
-            return
-
-        try:
-            # Use subprocess to ping with validated host
-            result = subprocess.run(
-                ["ping", "-c", "1", "-W", "1", ping_host],
-                capture_output=True,
-                text=True,
-                timeout=2,
-            )
-
-            if result.returncode == 0:
-                # Extract RTT from ping output
-                rtt_ms = None
-                for line in result.stdout.splitlines():
-                    if "time=" in line:
-                        try:
-                            parts = line.split("time=")[1].split()[0]
-                            rtt_ms = float(parts)
-                            break
-                        except (IndexError, ValueError):
-                            pass
-
-                db.insert_ping_sample(
-                    device_name=self.device_name,
-                    ts_epoch=ts_epoch,
-                    ok=True,
-                    rtt_ms=rtt_ms,
-                )
-            else:
-                stderr = result.stderr.strip()
-                stdout = result.stdout.strip()
-                detail = stderr or stdout
-                if detail:
-                    logger.debug(
-                        "Ping failed for %s (%s): %s",
-                        self.device_name,
-                        ping_host,
-                        detail,
-                    )
-                db.insert_ping_sample(
-                    device_name=self.device_name,
-                    ts_epoch=ts_epoch,
-                    ok=False,
-                    error_message="Not Responding",
-                )
-
-        except Exception as e:
-            logger.debug("Ping check failed for %s: %s", self.device_name, e)
-            db.insert_ping_sample(
-                device_name=self.device_name,
-                ts_epoch=ts_epoch,
-                ok=False,
-                error_message="Not Responding",
-            )
+        ping_target(db, self.device_name, ping_host)
 
 
 class Collector:
@@ -386,6 +384,7 @@ class Collector:
         """Initialize collector."""
         self.config = config
         self.devices = config.get_devices()
+        self.ping_targets = config.get_ping_targets()
         self.data_dir = Path("data")
         self.data_dir.mkdir(exist_ok=True)
 
@@ -476,7 +475,12 @@ class Collector:
         configured_commands = self.config.get_commands()
         if configured_commands:
             # Use global command list
-            return [cmd.get("command_text") for cmd in configured_commands]
+            command_texts = []
+            for cmd in configured_commands:
+                command_text = cmd.get("command_text")
+                if isinstance(command_text, str):
+                    command_texts.append(command_text)
+            return command_texts
         # Legacy per-device commands; assume all devices share same list
         all_cmds: List[str] = []
         for dev in self.devices:
@@ -484,10 +488,10 @@ class Collector:
         # Preserve order, remove duplicates
         seen = set()
         ordered: List[str] = []
-        for cmd in all_cmds:
-            if cmd not in seen:
-                ordered.append(cmd)
-                seen.add(cmd)
+        for legacy_cmd in all_cmds:
+            if legacy_cmd not in seen:
+                ordered.append(legacy_cmd)
+                seen.add(legacy_cmd)
         return ordered
 
     async def collect_commands(self, force: bool = False):
@@ -534,6 +538,16 @@ class Collector:
             future = loop.run_in_executor(self.executor, collector.ping_device, self.db)
             futures.append(future)
 
+        for target in self.ping_targets:
+            future = loop.run_in_executor(
+                self.executor,
+                ping_target,
+                self.db,
+                target["name"],
+                target["host"],
+            )
+            futures.append(future)
+
         if futures:
             await asyncio.gather(*futures, return_exceptions=True)
 
@@ -562,7 +576,7 @@ class Collector:
                 time.sleep(min(5, delay))
                 delay = min(5, delay * 2)
 
-    async def run(self):
+    async def run(self):  # noqa: C901
         """Main collection loop."""
         ping_interval_seconds = self.config.get_ping_interval_seconds()
 
@@ -685,10 +699,11 @@ async def async_main(config_path: str):
                         task.cancel()
 
         # Register signal handlers for SIGTERM, SIGINT, and SIGHUP
+        def make_signal_callback(sig: signal.Signals) -> Callable[[], None]:
+            return lambda: signal_handler(sig.name)
+
         for sig in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
-            loop.add_signal_handler(
-                sig, lambda s=sig: signal_handler(signal.Signals(s).name)
-            )
+            loop.add_signal_handler(sig, make_signal_callback(sig))
 
         # Run the collector
         await collector.run()

--- a/src/nw_watch/shared/config.py
+++ b/src/nw_watch/shared/config.py
@@ -1,3 +1,14 @@
+# Copyright 2026 icecake0141
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
 """Configuration loading and validation."""
 
 import logging
@@ -150,6 +161,10 @@ class Config:
     def get_devices(self) -> List[Dict[str, Any]]:
         """Configured devices."""
         return self.data.get("devices", [])
+
+    def get_ping_targets(self) -> List[Dict[str, str]]:
+        """Configured standalone ping targets."""
+        return self.data.get("ping_targets", [])
 
     def get_commands(self) -> List[Dict[str, Any]]:
         """Configured commands (global list)."""

--- a/src/nw_watch/shared/db.py
+++ b/src/nw_watch/shared/db.py
@@ -15,7 +15,7 @@ import logging
 import sqlite3
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +48,7 @@ class Database:
                     raise
                 time.sleep(min(5, delay))
                 delay = min(5, delay * 2)
+        raise RuntimeError(f"Unable to connect to SQLite database: {self.db_path}")
 
     def _init_schema(self):
         """Create database schema."""
@@ -128,7 +129,7 @@ class Database:
             return row[0]
         cursor.execute("INSERT INTO devices (name) VALUES (?)", (normalized_name,))
         self.conn.commit()
-        return cursor.lastrowid
+        return cast(int, cursor.lastrowid)
 
     def get_or_create_command(self, command_text: str) -> int:
         """Get or create command, return command ID."""
@@ -143,7 +144,7 @@ class Database:
             "INSERT INTO commands (command_text) VALUES (?)", (command_text,)
         )
         self.conn.commit()
-        return cursor.lastrowid
+        return cast(int, cursor.lastrowid)
 
     def insert_run(
         self,

--- a/src/nw_watch/shared/diff.py
+++ b/src/nw_watch/shared/diff.py
@@ -1,8 +1,19 @@
+# Copyright 2026 icecake0141
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
 """Diff generation utilities."""
 
 import difflib
 import html
-from typing import List, Tuple
+from typing import Tuple
 
 
 def generate_diff(old_text: str, new_text: str) -> str:

--- a/src/nw_watch/shared/export.py
+++ b/src/nw_watch/shared/export.py
@@ -1,3 +1,14 @@
+# Copyright 2026 icecake0141
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
 """Export utilities for network device monitoring data."""
 
 import csv
@@ -38,7 +49,7 @@ def export_run_as_text(run: Dict[str, Any], device: str, command: str) -> str:
     """
     lines = []
     lines.append("=" * 80)
-    lines.append(f"Network Watch - Command Output Export")
+    lines.append("Network Watch - Command Output Export")
     lines.append("=" * 80)
     lines.append(f"Device: {device}")
     lines.append(f"Command: {command}")
@@ -103,16 +114,17 @@ def export_bulk_runs_as_json(
     Returns:
         JSON string with all device outputs
     """
-    export_data = {
+    devices_data: Dict[str, List[Dict[str, Any]]] = {}
+    export_data: Dict[str, Any] = {
         "command": command,
         "export_timestamp": datetime.now(timezone.utc).strftime(
             "%Y-%m-%d %H:%M:%S UTC"
         ),
-        "devices": {},
+        "devices": devices_data,
     }
 
     for device, runs in runs_by_device.items():
-        export_data["devices"][device] = [
+        devices_data[device] = [
             {
                 "timestamp": format_timestamp_jst(run["ts_epoch"]),
                 "timestamp_epoch": run["ts_epoch"],
@@ -208,7 +220,7 @@ def export_diff_as_text(diff_html: str, label_a: str, label_b: str) -> str:
     """
     lines = []
     lines.append("=" * 80)
-    lines.append(f"Network Watch - Diff Export")
+    lines.append("Network Watch - Diff Export")
     lines.append("=" * 80)
     lines.append(f"Comparing: {label_a} vs {label_b}")
     lines.append(

--- a/src/nw_watch/shared/validation.py
+++ b/src/nw_watch/shared/validation.py
@@ -1,9 +1,34 @@
+# Copyright 2026 icecake0141
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
 """Configuration validation using Pydantic models."""
 
 import re
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field, field_validator, model_validator
+
+PING_HOST_PATTERN = r"^[a-zA-Z0-9\.\:\-\_]+$"
+
+
+def validate_ping_host_value(v: str, field_name: str = "ping_host") -> str:
+    """Validate ping host format to prevent command injection."""
+    if not v or not v.strip():
+        raise ValueError(f"{field_name} must not be empty")
+    if not re.match(PING_HOST_PATTERN, v):
+        raise ValueError(
+            f"Invalid {field_name} format '{v}'. Must contain only "
+            "alphanumeric characters, dots, colons, hyphens, and underscores."
+        )
+    return v
 
 
 class FiltersConfig(BaseModel):
@@ -132,14 +157,7 @@ class DeviceConfig(BaseModel):
     def validate_ping_host(cls, v: Optional[str]) -> Optional[str]:
         """Validate ping host format to prevent command injection."""
         if v is not None:
-            # Allow IPv4, IPv6, and hostnames
-            # This regex is permissive but prevents command injection
-            pattern = r"^[a-zA-Z0-9\.\:\-\_]+$"
-            if not re.match(pattern, v):
-                raise ValueError(
-                    f"Invalid ping_host format '{v}'. Must contain only "
-                    "alphanumeric characters, dots, colons, hyphens, and underscores."
-                )
+            return validate_ping_host_value(v)
         return v
 
     @model_validator(mode="after")
@@ -157,6 +175,27 @@ class GlobalFiltersConfig(BaseModel):
 
     line_exclude_substrings: Optional[List[str]] = Field(default_factory=list)
     output_exclude_substrings: Optional[List[str]] = Field(default_factory=list)
+
+
+class PingTargetConfig(BaseModel):
+    """Standalone ping target configuration."""
+
+    name: str
+    host: str
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        """Validate ping target name is not empty."""
+        if not v or not v.strip():
+            raise ValueError("Ping target name must not be empty")
+        return v
+
+    @field_validator("host")
+    @classmethod
+    def validate_host(cls, v: str) -> str:
+        """Validate ping target host format."""
+        return validate_ping_host_value(v, "ping target host")
 
 
 class WebSocketConfig(BaseModel):
@@ -241,6 +280,7 @@ class ConfigSchema(BaseModel):
 
     commands: List[CommandConfig] = Field(default_factory=list)
     devices: List[DeviceConfig] = Field(default_factory=list)
+    ping_targets: List[PingTargetConfig] = Field(default_factory=list)
 
     # Legacy fields for backward compatibility
     webapp: Optional[Dict[str, Any]] = None
@@ -302,6 +342,16 @@ class ConfigSchema(BaseModel):
             raise ValueError("At least one command must be configured")
         return v
 
+    @field_validator("ping_targets")
+    @classmethod
+    def validate_ping_targets_limit(
+        cls, v: List[PingTargetConfig]
+    ) -> List[PingTargetConfig]:
+        """Validate standalone ping target count."""
+        if len(v) > 3:
+            raise ValueError("ping_targets supports up to 3 targets")
+        return v
+
     @model_validator(mode="after")
     def validate_unique_device_names(self) -> "ConfigSchema":
         """Ensure device names are unique."""
@@ -309,6 +359,22 @@ class ConfigSchema(BaseModel):
         if len(names) != len(set(names)):
             duplicates = [name for name in names if names.count(name) > 1]
             raise ValueError(f"Duplicate device names found: {set(duplicates)}")
+        return self
+
+    @model_validator(mode="after")
+    def validate_unique_ping_target_names(self) -> "ConfigSchema":
+        """Ensure standalone ping target names are unique and separate from devices."""
+        names = [target.name for target in self.ping_targets]
+        if len(names) != len(set(names)):
+            duplicates = [name for name in names if names.count(name) > 1]
+            raise ValueError(f"Duplicate ping target names found: {set(duplicates)}")
+
+        device_names = {device.name for device in self.devices}
+        overlaps = sorted(device_names.intersection(names))
+        if overlaps:
+            raise ValueError(
+                f"ping_targets names must not duplicate device names: {overlaps}"
+            )
         return self
 
     @model_validator(mode="after")

--- a/src/nw_watch/webapp/main.py
+++ b/src/nw_watch/webapp/main.py
@@ -182,6 +182,23 @@ def get_db(history_size: int) -> Optional[Database]:
     return Database(str(DATABASE_PATH), history_size=history_size)
 
 
+def get_command_device_names(db: Database) -> list[str]:
+    """Return database device names that have command run records."""
+    all_devices = db.get_all_devices()
+    commands = db.get_all_commands()
+    if not commands:
+        return all_devices
+
+    command_devices = []
+    for device in all_devices:
+        if any(
+            db.get_latest_runs(device, command, limit=1, include_filtered=True)
+            for command in commands
+        ):
+            command_devices.append(device)
+    return command_devices
+
+
 def build_collector_status() -> Dict[str, object]:
     """Build a collector control status payload."""
     state = read_control_state()
@@ -236,7 +253,7 @@ async def get_devices():
         return JSONResponse({"devices": []})
 
     try:
-        devices = db.get_all_devices()
+        devices = get_command_device_names(db)
         return JSONResponse({"devices": devices})
     finally:
         db.close()
@@ -260,7 +277,7 @@ async def get_runs(
         return JSONResponse({"runs": {}})
 
     try:
-        devices = [device] if device else db.get_all_devices()
+        devices = [device] if device else get_command_device_names(db)
         result = {}
 
         for dev in devices:
@@ -284,7 +301,7 @@ async def get_runs_side_by_side(command: str):
         return JSONResponse({"devices": []})
 
     try:
-        devices = db.get_all_devices()
+        devices = get_command_device_names(db)
 
         if len(devices) < 2:
             # Need at least 2 devices for comparison
@@ -482,7 +499,7 @@ async def get_ping_status(window_seconds: int = 60):
                         avg_rtt = sum(rtts) / len(rtts)
                 # Build timeline (oldest -> newest)
                 samples_by_ts = {s["ts_epoch"]: s for s in samples}
-                timeline = []
+                timeline: list[Optional[bool]] = []
                 for offset in range(window_seconds - 1, -1, -1):
                     ts = timeline_end_ts - offset
                     sample = samples_by_ts.get(ts)
@@ -714,7 +731,7 @@ async def export_bulk(command: str, format: str = "json"):
         return JSONResponse({"error": "Database not available"}, status_code=503)
 
     try:
-        devices = db.get_all_devices()
+        devices = get_command_device_names(db)
         runs_by_device = {}
 
         for device in devices:
@@ -798,7 +815,11 @@ async def export_diff(
             )
             label_a = device_a
             label_b = device_b
-            filename_prefix = f"device_diff_{sanitize_filename(device_a)}_vs_{sanitize_filename(device_b)}_{sanitize_filename(command.replace(' ', '_'))}"
+            command_name = sanitize_filename(command.replace(" ", "_"))
+            filename_prefix = (
+                f"device_diff_{sanitize_filename(device_a)}_vs_"
+                f"{sanitize_filename(device_b)}_{command_name}"
+            )
         else:
             return JSONResponse({"error": "Invalid parameters"}, status_code=400)
 

--- a/src/nw_watch/webapp/websocket_manager.py
+++ b/src/nw_watch/webapp/websocket_manager.py
@@ -1,10 +1,21 @@
+# Copyright 2026 icecake0141
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
 """WebSocket connection manager for real-time updates."""
 
 import asyncio
 import json
 import logging
 import time
-from typing import Set
+from typing import Any, Optional, Set
 from fastapi import WebSocket
 
 logger = logging.getLogger(__name__)
@@ -63,7 +74,9 @@ class ConnectionManager:
                 self.active_connections -= disconnected
             logger.info("Removed %d disconnected clients", len(disconnected))
 
-    async def broadcast_update(self, update_type: str, data: dict = None):
+    async def broadcast_update(
+        self, update_type: str, data: Optional[dict[str, Any]] = None
+    ):
         """Broadcast an update notification to all clients."""
         message = {
             "type": update_type,

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -17,6 +17,7 @@ import signal
 import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+from subprocess import CompletedProcess
 
 from nw_watch.collector.main import Collector
 from nw_watch.shared.config import Config
@@ -298,6 +299,70 @@ devices:
             commands_executed = {e["command"] for e in execution_log}
             assert "show version" in commands_executed
             assert "show interfaces" in commands_executed
+
+            collector.stop()
+
+        finally:
+            os.chdir(original_cwd)
+            if "TEST_PASSWORD" in os.environ:
+                del os.environ["TEST_PASSWORD"]
+
+
+def test_collect_pings_includes_standalone_ping_targets():
+    """Test that standalone ping targets are collected separately from devices."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        cfg_path = Path(tmp_dir) / "config.yaml"
+        cfg_path.write_text("""
+interval_seconds: 5
+ping_interval_seconds: 1
+history_size: 10
+max_output_lines: 500
+
+ping_targets:
+  - name: "GatewayVIP"
+    host: "192.0.2.254"
+
+commands:
+  - name: "show_version"
+    command_text: "show version"
+
+devices:
+  - name: "DeviceA"
+    host: "192.168.1.1"
+    username: "admin"
+    password_env_key: "TEST_PASSWORD"
+    device_type: "cisco_ios"
+""")
+
+        os.environ["TEST_PASSWORD"] = "test"
+
+        config = Config(str(cfg_path))
+
+        original_cwd = Path.cwd()
+        try:
+            os.chdir(tmp_dir)
+
+            collector = Collector(config)
+            for device_collector in collector.device_collectors.values():
+                device_collector.ping_device = MagicMock()
+
+            with patch(
+                "nw_watch.collector.main.subprocess.run",
+                return_value=CompletedProcess(
+                    args=["ping"],
+                    returncode=0,
+                    stdout="64 bytes from 192.0.2.254: icmp_seq=1 ttl=64 time=1.23 ms",
+                    stderr="",
+                ),
+            ):
+                asyncio.run(collector.collect_pings())
+
+            target_samples = collector.db.get_ping_samples("GatewayVIP", since_ts=0)
+
+            assert collector.device_collectors["DeviceA"].ping_device.called
+            assert len(target_samples) == 1
+            assert target_samples[0]["ok"] == 1
+            assert target_samples[0]["rtt_ms"] == 1.23
 
             collector.stop()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,14 @@
+# Copyright 2026 icecake0141
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
 """Tests for configuration loader."""
 
 from pathlib import Path
@@ -14,6 +25,10 @@ ping_interval_seconds: 2
 ping_window_seconds: 90
 history_size: 5
 max_output_lines: 400
+
+ping_targets:
+  - name: "GatewayVIP"
+    host: "192.0.2.254"
 
 global_filters:
   line_exclude_substrings:
@@ -45,6 +60,7 @@ devices:
     assert config.get_ping_window_seconds() == 90
     assert config.get_history_size() == 5
     assert config.get_max_output_lines() == 400
+    assert config.get_ping_targets() == [{"name": "GatewayVIP", "host": "192.0.2.254"}]
     assert config.get_command_line_exclusions("show run") == ["local"]
     # Falls back to global output exclusions when none are set on the command
     assert config.get_command_output_exclusions("show run") == ["% Invalid"]

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -354,3 +354,57 @@ devices:
 
     with pytest.raises(ValueError, match="Invalid configuration"):
         Config(str(cfg_path))
+
+
+def test_valid_standalone_ping_targets(tmp_path):
+    """Test standalone ping target configuration."""
+    cfg_path = Path(tmp_path) / "config.yaml"
+    cfg_path.write_text("""
+ping_targets:
+  - name: "GatewayVIP"
+    host: "192.0.2.254"
+  - name: "DNS"
+    host: "example.com"
+commands:
+  - command_text: "show version"
+devices:
+  - name: "DeviceA"
+    host: "192.168.1.1"
+    username: "admin"
+    password_env_key: "TEST_PASSWORD"
+    device_type: "cisco_ios"
+""")
+
+    config = Config(str(cfg_path))
+
+    assert config.get_ping_targets() == [
+        {"name": "GatewayVIP", "host": "192.0.2.254"},
+        {"name": "DNS", "host": "example.com"},
+    ]
+
+
+def test_too_many_standalone_ping_targets(tmp_path):
+    """Test standalone ping targets are limited to three."""
+    cfg_path = Path(tmp_path) / "config.yaml"
+    cfg_path.write_text("""
+ping_targets:
+  - name: "Target1"
+    host: "192.0.2.1"
+  - name: "Target2"
+    host: "192.0.2.2"
+  - name: "Target3"
+    host: "192.0.2.3"
+  - name: "Target4"
+    host: "192.0.2.4"
+commands:
+  - command_text: "show version"
+devices:
+  - name: "DeviceA"
+    host: "192.168.1.1"
+    username: "admin"
+    password_env_key: "TEST_PASSWORD"
+    device_type: "cisco_ios"
+""")
+
+    with pytest.raises(ValueError, match="Invalid configuration"):
+        Config(str(cfg_path))

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -127,6 +127,21 @@ def test_get_devices(client):
     assert "DeviceB" in data["devices"]
 
 
+def test_get_devices_excludes_ping_only_targets(client):
+    """Test ping-only targets do not appear as command devices."""
+    db = Database("data/current.sqlite3")
+    db.insert_ping_sample(
+        device_name="GatewayVIP", ts_epoch=1000002, ok=True, rtt_ms=1.0
+    )
+    db.close()
+
+    response = client.get("/api/devices")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert "GatewayVIP" not in data["devices"]
+
+
 def test_get_runs(client):
     """Test getting command runs."""
     response = client.get("/api/runs/show%20version")


### PR DESCRIPTION
## Summary

- Add optional `ping_targets[]` configuration for up to three standalone ping-only IPs/hosts independent of SSH command devices.
- Reuse the existing ping sample storage and `/api/ping` UI/API path so standalone targets appear in ping tiles without changing existing device `ping_host` behavior.
- Keep command-device APIs filtered to devices that have command run records, so ping-only targets do not appear as SSH command devices.
- Update examples, README/spec docs, and tests.

## Rationale

Some monitored endpoints are not SSH command targets but still need reachability monitoring. This change lets users define named ping-only targets while preserving the existing command collection and device ping behavior.

## Validation

- `black --check --diff .`
- `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
- `flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude=.git,__pycache__,data,tests` — score: 10/10, output count 0
- `PYTHONPATH=src mypy --install-types --non-interactive --ignore-missing-imports src/nw_watch`
- `PYTHONPATH=src python -m pytest -q` — 265 passed, 2 skipped
- Pre-commit: not run; repository has no `.pre-commit-config.yaml`.

## Documentation

Updated `README.md`, `README.ja.md`, `docs/specification.md`, `docs/specification.ja.md`, and `config.example.yaml`.

## Backward Compatibility

Existing `devices[].ping_host` and command collection behavior are preserved. `ping_targets[]` is optional.

## LLM Involvement

Files created/modified with LLM assistance: `README.md`, `README.ja.md`, `config.example.yaml`, `docs/specification.md`, `docs/specification.ja.md`, `src/nw_watch/collector/main.py`, `src/nw_watch/shared/config.py`, `src/nw_watch/shared/db.py`, `src/nw_watch/shared/diff.py`, `src/nw_watch/shared/export.py`, `src/nw_watch/shared/validation.py`, `src/nw_watch/webapp/main.py`, `src/nw_watch/webapp/websocket_manager.py`, `tests/test_collector.py`, `tests/test_config.py`, `tests/test_validation.py`, `tests/test_webapp.py`.

Human review required for correctness, security, and licensing before merge.

## Checklist

- [x] License header added to new/modified source files and top-level LICENSE present
- [x] LLM attribution added to modified/generated files
- [x] Linting completed — score: 10/10 (command: `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`)
- [x] Tests pass locally (command: `PYTHONPATH=src python -m pytest -q`)
- [x] Static analysis/type checks pass (command: `PYTHONPATH=src mypy --install-types --non-interactive --ignore-missing-imports src/nw_watch`)
- [x] Formatting applied (command: `black --check --diff .`)
- [ ] Pre-commit hooks pass (not configured)
- [ ] CI build passes
- [ ] No merge conflicts with base branch
- [x] Changelog/versioning updated (not applicable)
- [x] Documentation updated (README, docs/, config example)
- [x] Examples/quick-start updated (config example)
- [x] Commit messages follow repository conventions
- [x] PR description includes: summary, rationale, tests, docs, migration notes
- [x] PR description explicitly lists LLM-modified files and human review notes
