### PR TITLE
[codex] Add SSH initial commands

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,3 +1,14 @@
+# Copyright 2026 icecake0141
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
 # Network Watch Configuration Example
 
 # Core intervals and history
@@ -22,6 +33,9 @@ ssh:
   connection_timeout: 100        # SSH connection timeout in seconds (default: 100)
   max_reconnect_attempts: 3      # Maximum reconnection attempts (default: 3)
   reconnect_backoff_base: 1.0    # Base time for exponential backoff in seconds (default: 1.0)
+  # Commands to run once immediately after every SSH login, before monitored commands
+  # initial_commands:
+  #   - "terminal length 0"
 
 # Global filters applied to every command (unless command override exists)
 global_filters:
@@ -60,6 +74,9 @@ devices:
     password_env_key: "DEVICEA_PASSWORD"  # Read password from environment
     device_type: "cisco_ios"              # netmiko device type
     ping_host: "192.168.1.1"
+    # Device-specific commands appended after ssh.initial_commands on every SSH login
+    # initial_commands:
+    #   - "enable"
 
   - name: "DeviceB"
     host: "192.168.1.2"

--- a/docs/specification.ja.md
+++ b/docs/specification.ja.md
@@ -48,6 +48,13 @@ English: [specification.md](specification.md)
 - `ssh.connection_timeout`
 - `ssh.max_reconnect_attempts`
 - `ssh.reconnect_backoff_base`
+- `ssh.initial_commands`
+- `devices[].initial_commands`
+
+`ssh.initial_commands` は全デバイスで SSH ログイン直後に一度実行されます。
+`devices[].initial_commands` は対象デバイスで追加実行されます。永続 SSH 接続では
+接続ごと、および再接続後に一度実行されます。永続接続を無効にした場合は、
+各コマンド用の短期セッション開始時に実行されます。
 
 設定例: [`config.example.yaml`](../config.example.yaml)
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -48,6 +48,13 @@ Main optional blocks:
 - `ssh.connection_timeout`
 - `ssh.max_reconnect_attempts`
 - `ssh.reconnect_backoff_base`
+- `ssh.initial_commands`
+- `devices[].initial_commands`
+
+`ssh.initial_commands` run once immediately after every SSH login for all devices.
+`devices[].initial_commands` are appended for that device. With persistent SSH
+connections they run once per connection, and after reconnects. Without persistent
+connections they run at the start of each short-lived command session.
 
 Reference example: [`config.example.yaml`](../config.example.yaml)
 

--- a/src/nw_watch/collector/main.py
+++ b/src/nw_watch/collector/main.py
@@ -98,6 +98,9 @@ class DeviceCollector:
         self.connection_timeout = self.config.get_connection_timeout()
         self.max_reconnect_attempts = self.config.get_max_reconnect_attempts()
         self.reconnect_backoff_base = self.config.get_reconnect_backoff_base()
+        self.initial_commands = self.config.get_device_initial_commands(
+            self.device_config
+        )
 
         # Connection state (only used if persistent_connections_enabled)
         self._connection: Optional[ConnectHandler] = None
@@ -132,7 +135,26 @@ class DeviceCollector:
         """Establish a new connection to the device."""
         params = self._get_connection_params()
         logger.info(f"Establishing SSH connection to {self.device_name}")
-        return ConnectHandler(**params)
+        connection = ConnectHandler(**params)
+        try:
+            self._run_initial_commands(connection)
+        except Exception:
+            try:
+                connection.disconnect()
+            except Exception:
+                pass
+            raise
+        return connection
+
+    def _run_initial_commands(self, connection: ConnectHandler) -> None:
+        """Run device login initialization commands for this SSH session."""
+        for initial_command in self.initial_commands:
+            logger.info(
+                "Executing initial SSH command for %s: %s",
+                self.device_name,
+                initial_command,
+            )
+            connection.send_command(initial_command)
 
     def _is_connection_alive(self) -> bool:
         """Check if the current connection is alive."""
@@ -213,30 +235,8 @@ class DeviceCollector:
                     connection = self._ensure_connected()
                     output = connection.send_command(command)
             else:
-                # Legacy mode: create new connection for each command
-                password = self.config.get_device_password(self.device_config)
-                if password is None:
-                    password_env_key = self.device_config.get("password_env_key")
-                    if password_env_key:
-                        raise ValueError(
-                            f"Password not provided for device '{self.device_name}'; "
-                            f"set environment variable '{password_env_key}'"
-                        )
-                    raise ValueError(
-                        f"Password not provided for device '{self.device_name}' "
-                        f"and no password_env_key set in config"
-                    )
-
-                # Connect to device
-                connection = ConnectHandler(
-                    device_type=self.device_config["device_type"],
-                    host=self.device_config["host"],
-                    port=self.device_config.get("port", 22),
-                    username=self.device_config["username"],
-                    password=password,
-                )
-
-                # Execute command
+                # Legacy mode: create new connection for each command.
+                connection = self._connect()
                 output = connection.send_command(command)
                 connection.disconnect()
 

--- a/src/nw_watch/shared/config.py
+++ b/src/nw_watch/shared/config.py
@@ -1,3 +1,14 @@
+# Copyright 2026 icecake0141
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
 """Configuration loading and validation."""
 
 import logging
@@ -144,6 +155,11 @@ class Config:
         ssh_config = self.data.get("ssh", {})
         return float(ssh_config.get("reconnect_backoff_base", 1.0))
 
+    def get_global_initial_commands(self) -> List[str]:
+        """Initial commands to run after every SSH login."""
+        ssh_config = self.data.get("ssh", {})
+        return list(ssh_config.get("initial_commands", []))
+
     # ------------------------------------------------------------------ #
     # Devices and commands
     # ------------------------------------------------------------------ #
@@ -168,6 +184,12 @@ class Config:
                 device.get("name", "unknown"),
             )
         return fallback
+
+    def get_device_initial_commands(self, device: Dict[str, Any]) -> List[str]:
+        """Initial commands for a device, including global SSH commands first."""
+        return self.get_global_initial_commands() + list(
+            device.get("initial_commands", [])
+        )
 
     # ------------------------------------------------------------------ #
     # Filters

--- a/src/nw_watch/shared/validation.py
+++ b/src/nw_watch/shared/validation.py
@@ -1,3 +1,14 @@
+# Copyright 2026 icecake0141
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
 """Configuration validation using Pydantic models."""
 
 import re
@@ -68,6 +79,7 @@ class DeviceConfig(BaseModel):
     password: Optional[str] = None
     device_type: str
     ping_host: Optional[str] = None
+    initial_commands: List[str] = Field(default_factory=list)
 
     @field_validator("name")
     @classmethod
@@ -142,6 +154,15 @@ class DeviceConfig(BaseModel):
                 )
         return v
 
+    @field_validator("initial_commands")
+    @classmethod
+    def validate_initial_commands(cls, v: List[str]) -> List[str]:
+        """Validate initial commands are non-empty strings."""
+        for command in v:
+            if not command or not command.strip():
+                raise ValueError("initial_commands must not contain empty commands")
+        return v
+
     @model_validator(mode="after")
     def validate_password_config(self) -> "DeviceConfig":
         """Ensure either password_env_key or password is provided."""
@@ -181,6 +202,7 @@ class SSHConfig(BaseModel):
     connection_timeout: int = Field(default=100, gt=0)
     max_reconnect_attempts: int = Field(default=3, ge=0)
     reconnect_backoff_base: float = Field(default=1.0, gt=0)
+    initial_commands: List[str] = Field(default_factory=list)
 
     @field_validator("connection_timeout")
     @classmethod
@@ -206,6 +228,15 @@ class SSHConfig(BaseModel):
         """Validate reconnect backoff base is positive."""
         if v <= 0:
             raise ValueError(f"SSH reconnect_backoff_base must be positive, got {v}")
+        return v
+
+    @field_validator("initial_commands")
+    @classmethod
+    def validate_initial_commands(cls, v: List[str]) -> List[str]:
+        """Validate initial commands are non-empty strings."""
+        for command in v:
+            if not command or not command.strip():
+                raise ValueError("SSH initial_commands must not contain empty commands")
         return v
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,14 @@
+# Copyright 2026 icecake0141
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
 """Tests for configuration loader."""
 
 from pathlib import Path
@@ -21,6 +32,10 @@ global_filters:
   output_exclude_substrings:
     - "% Invalid"
 
+ssh:
+  initial_commands:
+    - "terminal length 0"
+
 commands:
   - name: "cmd1"
     command_text: "show run"
@@ -34,6 +49,8 @@ devices:
     username: "admin"
     password_env_key: "PW_A"
     device_type: "cisco_ios"
+    initial_commands:
+      - "enable"
 """)
 
     monkeypatch.setenv("PW_A", "secret")
@@ -49,3 +66,8 @@ devices:
     # Falls back to global output exclusions when none are set on the command
     assert config.get_command_output_exclusions("show run") == ["% Invalid"]
     assert config.get_device_password(config.get_devices()[0]) == "secret"
+    assert config.get_global_initial_commands() == ["terminal length 0"]
+    assert config.get_device_initial_commands(config.get_devices()[0]) == [
+        "terminal length 0",
+        "enable",
+    ]

--- a/tests/test_persistent_connections.py
+++ b/tests/test_persistent_connections.py
@@ -14,7 +14,7 @@
 import os
 import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 from netmiko.exceptions import (
     NetmikoAuthenticationException,
@@ -437,6 +437,97 @@ devices:
         db.close()
 
 
+def test_initial_commands_run_once_per_persistent_connection():
+    """Test initial commands run once when a persistent connection is created."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        cfg_path = Path(tmp_dir) / "config.yaml"
+        cfg_path.write_text("""
+interval_seconds: 5
+ssh:
+  initial_commands:
+    - "terminal length 0"
+commands:
+  - name: "test"
+    command_text: "show version"
+devices:
+  - name: "TestDevice"
+    host: "192.168.1.1"
+    username: "admin"
+    password_env_key: "TEST_PASSWORD"
+    device_type: "cisco_ios"
+    initial_commands:
+      - "enable"
+""")
+
+        os.environ["TEST_PASSWORD"] = "test"
+        config = Config(str(cfg_path))
+        db_path = Path(tmp_dir) / "test.db"
+        db = Database(str(db_path))
+
+        device_config = config.get_devices()[0]
+        collector = DeviceCollector(device_config, config)
+
+        with patch("nw_watch.collector.main.ConnectHandler") as mock_handler:
+            mock_connection = MagicMock()
+            mock_connection.send_command.return_value = "Version output"
+            mock_connection.find_prompt.return_value = "Router#"
+            mock_handler.return_value = mock_connection
+
+            collector.execute_command("show version", db)
+            collector.execute_command("show version", db)
+
+            mock_connection.send_command.assert_has_calls(
+                [
+                    call("terminal length 0"),
+                    call("enable"),
+                    call("show version"),
+                    call("show version"),
+                ]
+            )
+            assert mock_handler.call_count == 1
+
+        db.close()
+
+
+def test_initial_command_failure_disconnects_new_connection():
+    """Test failed initialization closes the newly-created connection."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        cfg_path = Path(tmp_dir) / "config.yaml"
+        cfg_path.write_text("""
+interval_seconds: 5
+commands:
+  - name: "test"
+    command_text: "show version"
+devices:
+  - name: "TestDevice"
+    host: "192.168.1.1"
+    username: "admin"
+    password_env_key: "TEST_PASSWORD"
+    device_type: "cisco_ios"
+    initial_commands:
+      - "enable"
+""")
+
+        os.environ["TEST_PASSWORD"] = "test"
+        config = Config(str(cfg_path))
+        device_config = config.get_devices()[0]
+        collector = DeviceCollector(device_config, config)
+
+        with patch("nw_watch.collector.main.ConnectHandler") as mock_handler:
+            mock_connection = MagicMock()
+            mock_connection.send_command.side_effect = Exception("enable failed")
+            mock_handler.return_value = mock_connection
+
+            try:
+                collector._connect()
+            except Exception as exc:
+                assert str(exc) == "enable failed"
+            else:
+                raise AssertionError("Expected _connect to raise")
+
+            mock_connection.disconnect.assert_called_once()
+
+
 def test_execute_command_without_persistent_connection():
     """Test command execution without persistent connections (legacy mode)."""
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -481,5 +572,56 @@ devices:
 
             # Verify disconnect was called twice
             assert mock_connection.disconnect.call_count == 2
+
+        db.close()
+
+
+def test_initial_commands_run_for_each_short_lived_connection():
+    """Test initial commands run before monitored commands without persistence."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        cfg_path = Path(tmp_dir) / "config.yaml"
+        cfg_path.write_text("""
+interval_seconds: 5
+ssh:
+  persistent_connections: false
+commands:
+  - name: "test"
+    command_text: "show version"
+devices:
+  - name: "TestDevice"
+    host: "192.168.1.1"
+    username: "admin"
+    password_env_key: "TEST_PASSWORD"
+    device_type: "cisco_ios"
+    initial_commands:
+      - "enable"
+""")
+
+        os.environ["TEST_PASSWORD"] = "test"
+        config = Config(str(cfg_path))
+        db_path = Path(tmp_dir) / "test.db"
+        db = Database(str(db_path))
+
+        device_config = config.get_devices()[0]
+        collector = DeviceCollector(device_config, config)
+
+        with patch("nw_watch.collector.main.ConnectHandler") as mock_handler:
+            first_connection = MagicMock()
+            first_connection.send_command.return_value = "Version output"
+            second_connection = MagicMock()
+            second_connection.send_command.return_value = "Version output"
+            mock_handler.side_effect = [first_connection, second_connection]
+
+            collector.execute_command("show version", db)
+            collector.execute_command("show version", db)
+
+            first_connection.send_command.assert_has_calls(
+                [call("enable"), call("show version")]
+            )
+            second_connection.send_command.assert_has_calls(
+                [call("enable"), call("show version")]
+            )
+            first_connection.disconnect.assert_called_once()
+            second_connection.disconnect.assert_called_once()
 
         db.close()


### PR DESCRIPTION
## Summary

Adds optional SSH initial commands that run immediately after login and before monitored commands.

- Adds global `ssh.initial_commands` for all devices.
- Adds per-device `devices[].initial_commands`, appended after global commands.
- Runs initial commands once per persistent SSH connection, including reconnects.
- Runs initial commands at the start of each short-lived session when persistent connections are disabled.
- Documents the new options in `config.example.yaml` and the English/Japanese specifications.

## Rationale

Some network devices require a one-time session setup command before normal collection, such as Cisco IOS `enable` or a command that enters a virtual-router context. This keeps that setup optional so environments that do not need it continue to execute only configured monitored commands.

## Validation

- `PYTHONPATH=src pytest tests/test_config.py tests/test_persistent_connections.py -q` -> 20 passed
- `PYTHONPATH=src pytest -q` -> 264 passed, 2 skipped
- `black --check --diff src/nw_watch/shared/validation.py src/nw_watch/shared/config.py src/nw_watch/collector/main.py tests/test_config.py tests/test_persistent_connections.py` -> passed
- `git diff --check` -> passed
- `flake8 --extend-ignore=E501 src/nw_watch/shared/validation.py src/nw_watch/shared/config.py src/nw_watch/collector/main.py tests/test_config.py tests/test_persistent_connections.py` -> passed

Known existing validation gaps:

- `flake8 src tests` currently fails on pre-existing repository-wide E501/F401/F841/etc. issues outside this change.
- `mypy --install-types --non-interactive --ignore-missing-imports src/nw_watch` currently fails on pre-existing type issues in `shared/export.py`, `shared/db.py`, `collector/main.py`, `webapp/websocket_manager.py`, and `webapp/main.py`.
- No `.pre-commit-config.yaml` was present, so pre-commit hooks were not run.

## Documentation

Updated:

- `config.example.yaml`
- `docs/specification.md`
- `docs/specification.ja.md`

## Backward Compatibility

Backward compatible. If neither `ssh.initial_commands` nor `devices[].initial_commands` is configured, no additional login commands are sent and existing behavior is unchanged.

## LLM Involvement

Files modified with LLM assistance:

- `config.example.yaml`
- `docs/specification.ja.md`
- `docs/specification.md`
- `src/nw_watch/collector/main.py`
- `src/nw_watch/shared/config.py`
- `src/nw_watch/shared/validation.py`
- `tests/test_config.py`
- `tests/test_persistent_connections.py`

Human review note: diff reviewed locally before commit; final human code review is still required before merge.

## Checklist

- [x] License header added to new/modified source/config files and top-level LICENSE present
- [x] LLM attribution added to modified/generated files
- [x] Linting completed for modified Python files (command: `flake8 --extend-ignore=E501 ...`)
- [x] Tests pass locally (command: `PYTHONPATH=src pytest -q`)
- [ ] Static analysis/type checks pass (command: `mypy --install-types --non-interactive --ignore-missing-imports src/nw_watch`; existing failures remain)
- [x] Formatting checked (command: `black --check --diff ...`)
- [ ] Pre-commit hooks pass (no `.pre-commit-config.yaml` present)
- [ ] CI build passes
- [x] No merge conflicts observed locally
- [ ] Changelog/versioning updated (not applicable unless project requires it)
- [x] Documentation updated (config example and specifications)
- [x] Examples/quick-start updated where applicable (`config.example.yaml`)
- [x] Commit messages follow repository conventions
- [x] PR description includes summary, rationale, tests, docs, and migration notes
- [x] PR description explicitly lists LLM-modified files and review notes