### PR TITLE
Add debug log page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ data/*.sqlite3.tmp
 data/*.sqlite3-journal
 data/*.sqlite3-wal
 data/*.sqlite3-shm
+data/logs/*.log
 
 # Runtime control state
 control/*.pid

--- a/src/nw_watch/collector/main.py
+++ b/src/nw_watch/collector/main.py
@@ -38,11 +38,13 @@ from nw_watch.shared.control_state import (
     update_control_state,
 )
 from nw_watch.shared.db import Database
+from nw_watch.shared.debug import log_ssh_session, setup_debug_file_logging
 from nw_watch.shared.filters import process_output
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
+setup_debug_file_logging()
 logger = logging.getLogger(__name__)
 PING_HOST_PATTERN = re.compile(r"^[a-zA-Z0-9._:-]+$")
 
@@ -255,6 +257,10 @@ class DeviceCollector:
         """Establish a new connection to the device."""
         params = self._get_connection_params()
         logger.info(f"Establishing SSH connection to {self.device_name}")
+        log_ssh_session(
+            f"[{self.device_name}] connect host={params['host']} port={params['port']} "
+            f"username={params['username']}"
+        )
         connection = ConnectHandler(**params)
         try:
             self._run_initial_commands(connection)
@@ -274,7 +280,10 @@ class DeviceCollector:
                 self.device_name,
                 initial_command,
             )
-            connection.send_command(initial_command)
+            log_ssh_session(f"[{self.device_name}] initial-command> {initial_command}")
+            output = connection.send_command(initial_command)
+            if output:
+                log_ssh_session(f"[{self.device_name}] initial-output\n{output}")
 
     def _is_connection_alive(self) -> bool:
         """Check if the current connection is alive."""
@@ -353,12 +362,15 @@ class DeviceCollector:
                 # Use persistent connection with lock
                 with self._connection_lock:
                     connection = self._ensure_connected()
+                    log_ssh_session(f"[{self.device_name}] command> {command}")
                     output = connection.send_command(command)
             else:
                 # Legacy mode: create new connection for each command.
                 connection = self._connect()
+                log_ssh_session(f"[{self.device_name}] command> {command}")
                 output = connection.send_command(command)
                 connection.disconnect()
+                log_ssh_session(f"[{self.device_name}] disconnect")
 
             duration_ms = (time.time() - start_time) * 1000
 
@@ -388,6 +400,10 @@ class DeviceCollector:
             logger.info(
                 f"Executed '{command}' on {self.device_name} in {duration_ms:.2f}ms"
             )
+            log_ssh_session(
+                f"[{self.device_name}] output command={command!r} "
+                f"duration_ms={duration_ms:.2f}\n{output}"
+            )
 
         except Exception as e:
             duration_ms = (time.time() - start_time) * 1000
@@ -415,6 +431,10 @@ class DeviceCollector:
                 duration_ms,
                 str(e).strip(),
                 exc_info=logger.isEnabledFor(logging.DEBUG),
+            )
+            log_ssh_session(
+                f"[{self.device_name}] error command={command!r} "
+                f"category={error_code} message={error_msg}"
             )
 
     def close(self) -> None:
@@ -639,7 +659,7 @@ class Collector:
                 return
             except Exception as e:
                 logger.error(
-                    f"Error updating current database (attempt {attempt+1}): {e}"
+                    f"Error updating current database (attempt {attempt + 1}): {e}"
                 )
                 if attempt == 4:
                     return
@@ -723,7 +743,6 @@ class Collector:
         async def ping_loop():
             try:
                 while self.running:
-                    control_state = self._load_control_state()
                     await self.collect_pings()
                     await asyncio.sleep(ping_interval_seconds)
             except asyncio.CancelledError:

--- a/src/nw_watch/runtime.py
+++ b/src/nw_watch/runtime.py
@@ -21,9 +21,12 @@ import time
 from pathlib import Path
 from typing import Sequence
 
+from nw_watch.shared.debug import setup_debug_file_logging
+
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
+setup_debug_file_logging()
 logger = logging.getLogger(__name__)
 
 
@@ -72,6 +75,7 @@ def run(args: argparse.Namespace) -> int:
     env = os.environ.copy()
     env["NW_WATCH_CONFIG"] = str(config_path)
     env["NW_WATCH_DATA_DIR"] = str(data_dir)
+    env.setdefault("NW_WATCH_LOG_DIR", str(data_dir / "logs"))
 
     collector_command = [
         sys.executable,

--- a/src/nw_watch/shared/debug.py
+++ b/src/nw_watch/shared/debug.py
@@ -1,0 +1,97 @@
+# Copyright 2026 icecake0141
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+"""Debug logging and redaction helpers."""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+APP_LOG_FILENAME = "app.log"
+SSH_LOG_FILENAME = "ssh_sessions.log"
+LOG_DIR_ENV = "NW_WATCH_LOG_DIR"
+DATA_DIR_ENV = "NW_WATCH_DATA_DIR"
+
+MASK = "********"
+SENSITIVE_KEY_NAMES = {
+    "password",
+    "secret",
+    "enable_secret",
+    "token",
+    "api_key",
+    "private_key",
+}
+
+
+def get_log_dir() -> Path:
+    """Return the directory used for debug log files."""
+    configured = os.environ.get(LOG_DIR_ENV)
+    if configured:
+        return Path(configured)
+    return Path(os.environ.get(DATA_DIR_ENV, "data")) / "logs"
+
+
+def get_app_log_path() -> Path:
+    """Return the application debug log path."""
+    return get_log_dir() / APP_LOG_FILENAME
+
+
+def get_ssh_log_path() -> Path:
+    """Return the SSH session debug log path."""
+    return get_log_dir() / SSH_LOG_FILENAME
+
+
+def setup_debug_file_logging() -> None:
+    """Attach an application file log handler once per process."""
+    log_path = get_app_log_path()
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    handler_key = str(log_path.resolve())
+
+    root_logger = logging.getLogger()
+    for handler in root_logger.handlers:
+        if getattr(handler, "_nw_watch_debug_log_path", None) == handler_key:
+            return
+
+    handler = logging.FileHandler(log_path, encoding="utf-8")
+    handler.setFormatter(
+        logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    )
+    handler._nw_watch_debug_log_path = handler_key  # type: ignore[attr-defined]
+    root_logger.addHandler(handler)
+
+
+def log_ssh_session(message: str) -> None:
+    """Append a line to the SSH session debug log."""
+    log_path = get_ssh_log_path()
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(message.rstrip("\n") + "\n")
+
+
+def mask_sensitive_config(value: Any) -> Any:
+    """Return a copy of config-like data with sensitive values masked."""
+    if isinstance(value, dict):
+        masked: dict[str, Any] = {}
+        for key, item in value.items():
+            lowered = str(key).lower()
+            if lowered == "password_env_key":
+                masked[key] = item
+            elif lowered in SENSITIVE_KEY_NAMES or lowered.endswith("_password"):
+                masked[key] = MASK if item is not None else None
+            else:
+                masked[key] = mask_sensitive_config(item)
+        return masked
+    if isinstance(value, list):
+        return [mask_sensitive_config(item) for item in value]
+    return value

--- a/src/nw_watch/webapp/main.py
+++ b/src/nw_watch/webapp/main.py
@@ -12,6 +12,7 @@
 """Web application for network device monitoring."""
 
 import asyncio
+import json
 import logging
 import math
 import os
@@ -25,7 +26,13 @@ from typing import Any, Dict, Optional, Tuple
 from yaml import YAMLError
 
 from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
-from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse, Response
+from fastapi.responses import (
+    HTMLResponse,
+    JSONResponse,
+    PlainTextResponse,
+    Response,
+    StreamingResponse,
+)
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
@@ -38,6 +45,12 @@ from nw_watch.shared.control_state import (
     update_control_state,
 )
 from nw_watch.shared.db import Database
+from nw_watch.shared.debug import (
+    get_app_log_path,
+    get_ssh_log_path,
+    mask_sensitive_config,
+    setup_debug_file_logging,
+)
 from nw_watch.shared.diff import generate_side_by_side_diff, generate_inline_char_diff
 from nw_watch.shared.export import (
     export_run_as_text,
@@ -51,6 +64,7 @@ from nw_watch.shared.export import (
 from nw_watch.webapp.websocket_manager import manager
 
 logger = logging.getLogger(__name__)
+setup_debug_file_logging()
 
 # Background task state
 _background_task = None
@@ -272,6 +286,12 @@ def build_collector_status() -> Dict[str, object]:
 async def index(request: Request):
     """Render main page."""
     return templates.TemplateResponse(request, "index.html")
+
+
+@app.get("/debug", response_class=HTMLResponse)
+async def debug_page(request: Request):
+    """Render debug page."""
+    return templates.TemplateResponse(request, "debug.html")
 
 
 @app.get("/api/commands")
@@ -727,6 +747,81 @@ async def get_config():
                 "websocket_enabled": False,
             }
         )
+
+
+@app.get("/api/debug/config")
+async def get_debug_config():
+    """Get masked configuration details for the debug page."""
+    try:
+        config = load_config()
+        masked = mask_sensitive_config(config.data)
+        return JSONResponse({"config": masked})
+    except Exception as exc:
+        logger.error("Failed to load debug config: %s", exc)
+        return JSONResponse({"error": "Failed to load configuration."}, status_code=500)
+
+
+def resolve_ssh_log_device(line: str, current_device: Optional[str]) -> Optional[str]:
+    """Return the SSH log device for a line, preserving multiline output context."""
+    match = re.match(r"^\[([^\]]+)\]", line)
+    if match:
+        return match.group(1)
+    return current_device
+
+
+async def stream_log_file(request: Request, path: Path, device: Optional[str] = None):
+    """Yield file lines as server-sent events."""
+    offset = 0
+    current_device: Optional[str] = None
+    if path.exists():
+        offset = max(0, path.stat().st_size - 16000)
+
+    yield "event: status\ndata: connected\n\n"
+
+    while True:
+        if await request.is_disconnected():
+            break
+
+        if not path.exists():
+            yield f"event: log\ndata: {json.dumps('log file not created yet')}\n\n"
+            await asyncio.sleep(1)
+            continue
+
+        with path.open("r", encoding="utf-8", errors="replace") as handle:
+            handle.seek(offset)
+            lines = handle.readlines()
+            offset = handle.tell()
+
+        for raw_line in lines:
+            line = raw_line.rstrip("\n")
+            if device is not None:
+                current_device = resolve_ssh_log_device(line, current_device)
+                if current_device != device:
+                    continue
+            data = json.dumps(line)
+            yield f"event: log\ndata: {data}\n\n"
+
+        await asyncio.sleep(1)
+
+
+@app.get("/api/debug/logs/{log_name}")
+async def stream_debug_log(
+    request: Request, log_name: str, device: Optional[str] = None
+):
+    """Stream debug log lines."""
+    log_paths = {
+        "app": get_app_log_path(),
+        "ssh": get_ssh_log_path(),
+    }
+    path = log_paths.get(log_name)
+    if path is None:
+        return JSONResponse({"error": "Unknown log stream."}, status_code=404)
+
+    return StreamingResponse(
+        stream_log_file(request, path, device=device if log_name == "ssh" else None),
+        media_type="text/event-stream",
+        headers={"Cache-Control": NO_CACHE_CONTROL},
+    )
 
 
 @app.get("/api/collector/status")

--- a/src/nw_watch/webapp/static/app.js
+++ b/src/nw_watch/webapp/static/app.js
@@ -42,13 +42,13 @@ class NetworkWatch {
             updated_at: 0
         };
         this.collectorPollIntervalMs = 5000;
-        
+
         // WebSocket reconnection settings
         this.maxWebSocketReconnectAttempts = 5;
         this.baseReconnectDelay = 1000;  // 1 second base delay
         this.maxReconnectDelay = 30000;  // 30 seconds max delay
         this.reconnectBackoffMultiplier = 2;  // Exponential backoff multiplier
-        
+
         // Diff state preservation
         // Structure: { "command:device": { type: 'history'|'device', content: '...', format: 'html'|'text', otherDevice: '...' } }
         this.diffStates = {};
@@ -58,23 +58,23 @@ class NetworkWatch {
         this.latestSideBySideData = {};
         this.outputSnapshots = {};
         this.outputViewModes = {};
-        
+
         this.init();
     }
-    
+
     async init() {
         // Load configuration
         await this.loadConfig();
-        
+
         // Load initial data
         await this.loadDevices();
         await this.loadCommands();
         await this.loadCollectorStatus();
-        
+
         // Setup UI
         this.setupEventListeners();
         this.renderCommandTabs();
-        
+
         // Start WebSocket or polling based on config
         if (this.config.websocket_enabled) {
             this.connectWebSocket();
@@ -83,7 +83,7 @@ class NetworkWatch {
         }
 
         this.startCollectorStatusPolling();
-        
+
         // Initial data load
         await this.updatePingStatus();
         if (this.commands.length > 0) {
@@ -98,7 +98,7 @@ class NetworkWatch {
             context: context
         });
     }
-    
+
     async loadConfig() {
         try {
             const response = await fetch('/api/config');
@@ -108,7 +108,7 @@ class NetworkWatch {
             this.logClientError('CONFIG_LOAD_FAILED', error, { endpoint: '/api/config' });
         }
     }
-    
+
     async loadDevices() {
         try {
             const response = await fetch('/api/devices');
@@ -118,7 +118,7 @@ class NetworkWatch {
             this.logClientError('DEVICES_LOAD_FAILED', error, { endpoint: '/api/devices' });
         }
     }
-    
+
     async loadCommands() {
         try {
             const response = await fetch('/api/commands');
@@ -140,17 +140,17 @@ class NetworkWatch {
             this.updateCollectorControls(true);
         }
     }
-    
+
     setupEventListeners() {
         // Theme toggle
         document.getElementById('themeToggle').addEventListener('click', () => {
             this.toggleTheme();
         });
-        
+
         document.getElementById('toggleAutoRefresh').addEventListener('click', () => {
             this.toggleAutoRefresh();
         });
-        
+
         document.getElementById('manualRefresh').addEventListener('click', () => {
             this.manualRefresh();
         });
@@ -170,7 +170,7 @@ class NetworkWatch {
         document.getElementById('stopCollector').addEventListener('click', () => {
             this.stopCollector();
         });
-        
+
         // Load saved theme preference
         this.loadThemePreference();
     }
@@ -192,18 +192,18 @@ class NetworkWatch {
             output.style.height = `${this.sideBySideOutputHeight}px`;
         });
     }
-    
+
     toggleTheme() {
         const body = document.body;
         const isDark = body.classList.toggle('dark-theme');
-        
+
         // Save preference to localStorage
         localStorage.setItem('theme', isDark ? 'dark' : 'light');
     }
-    
+
     loadThemePreference() {
         const savedTheme = localStorage.getItem('theme');
-        
+
         // Check system preference with fallback for older browsers
         let prefersDark = false;
         try {
@@ -212,17 +212,17 @@ class NetworkWatch {
             // Older browsers may not support matchMedia
             console.log('matchMedia not supported, using light theme');
         }
-        
+
         // Apply saved theme, or use system preference if no saved theme
         if (savedTheme === 'dark' || (!savedTheme && prefersDark)) {
             document.body.classList.add('dark-theme');
         }
     }
-    
+
     toggleAutoRefresh() {
         this.autoRefresh = !this.autoRefresh;
         const btn = document.getElementById('toggleAutoRefresh');
-        
+
         if (this.autoRefresh) {
             btn.textContent = '⏸ Pause Auto-Refresh';
             if (this.config.websocket_enabled) {
@@ -441,7 +441,7 @@ class NetworkWatch {
             this.websocket.onclose = () => {
                 console.log('WebSocket disconnected');
                 this.websocket = null;
-                
+
                 // Fallback to polling if WebSocket fails
                 if (this.autoRefresh && !this.isPolling) {
                     console.log('Falling back to polling');
@@ -452,7 +452,7 @@ class NetworkWatch {
                 if (this.websocketReconnectAttempts < this.maxWebSocketReconnectAttempts) {
                     this.websocketReconnectAttempts++;
                     const delay = Math.min(
-                        this.maxReconnectDelay, 
+                        this.maxReconnectDelay,
                         this.baseReconnectDelay * Math.pow(this.reconnectBackoffMultiplier, this.websocketReconnectAttempts - 1)
                     );
                     console.log(`Attempting to reconnect WebSocket in ${delay}ms (attempt ${this.websocketReconnectAttempts})`);
@@ -520,26 +520,26 @@ class NetworkWatch {
         }
         this.pauseBanner.style.display = show ? 'block' : 'none';
     }
-    
+
     async manualRefresh() {
         await this.updatePingStatus();
         if (this.currentCommand) {
             await this.updateCommandData(this.currentCommand);
         }
     }
-    
+
     startPolling() {
         if (!this.autoRefresh) return;
-        
+
         this.isPolling = true;
-        
+
         // Poll ping status
         this.pingPollTimer = setInterval(() => {
             if (this.autoRefresh) {
                 this.updatePingStatus();
             }
         }, this.config.ping_poll_interval_seconds * 1000);
-        
+
         // Poll run data
         this.runPollTimer = setInterval(() => {
             if (this.autoRefresh && this.currentCommand) {
@@ -547,10 +547,10 @@ class NetworkWatch {
             }
         }, this.config.run_poll_interval_seconds * 1000);
     }
-    
+
     stopPolling() {
         this.isPolling = false;
-        
+
         if (this.pingPollTimer) {
             clearInterval(this.pingPollTimer);
             this.pingPollTimer = null;
@@ -560,11 +560,11 @@ class NetworkWatch {
             this.runPollTimer = null;
         }
     }
-    
+
     renderCommandTabs() {
         const tabsContainer = document.getElementById('commandTabs');
         tabsContainer.innerHTML = '';
-        
+
         this.commands.forEach(command => {
             const tab = document.createElement('button');
             tab.className = 'tab';
@@ -573,10 +573,10 @@ class NetworkWatch {
             tabsContainer.appendChild(tab);
         });
     }
-    
+
     async switchToCommand(command) {
         this.currentCommand = command;
-        
+
         // Update active tab
         document.querySelectorAll('.tab').forEach(tab => {
             if (tab.textContent === command) {
@@ -585,70 +585,70 @@ class NetworkWatch {
                 tab.classList.remove('active');
             }
         });
-        
+
         // Load command data
         await this.updateCommandData(command);
     }
-    
+
     async updateCommandData(command) {
         try {
             // Fetch side-by-side data for character-level diff
             const sideBySideResponse = await fetch(`/api/runs/${encodeURIComponent(command)}/side_by_side`);
             const sideBySideData = await sideBySideResponse.json();
             this.latestSideBySideData[command] = sideBySideData;
-            
+
             // Also fetch regular run data for history
             const response = await fetch(`/api/runs/${encodeURIComponent(command)}`);
             const data = await response.json();
-            
+
             this.renderCommandContent(command, data.runs, sideBySideData);
         } catch (error) {
             this.logClientError('COMMAND_DATA_LOAD_FAILED', error, { command });
         }
     }
-    
+
     renderCommandContent(command, runsData, sideBySideData) {
         const contentContainer = document.getElementById('commandContent');
-        
+
         // Save current diff states before clearing
         this.saveDiffStates(command);
         this.saveSideBySideScrollStates(command);
-        
+
         contentContainer.innerHTML = '';
-        
+
         // Check if we have side-by-side data
         if (sideBySideData && sideBySideData.devices && sideBySideData.devices.length >= 2) {
             // Render side-by-side comparison view
             this.renderSideBySideView(command, this.getDisplayedSideBySideData(command, sideBySideData));
-            
+
             // Add separator
             const separator = document.createElement('hr');
             separator.style.margin = '30px 0';
             contentContainer.appendChild(separator);
         }
-        
+
         // Render traditional per-device run history
         for (const [device, runs] of Object.entries(runsData)) {
             const deviceSection = document.createElement('div');
             deviceSection.className = 'device-section';
-            
+
             const deviceHeader = document.createElement('div');
             deviceHeader.className = 'device-header-section';
             deviceHeader.innerHTML = `<h3>Device: ${device}</h3>`;
-            
+
             // Add bulk export button
             const bulkExportBtn = document.createElement('button');
             bulkExportBtn.className = 'bulk-export-btn';
             bulkExportBtn.textContent = '📦 Export All Outputs (JSON)';
             bulkExportBtn.addEventListener('click', () => this.exportBulk(command));
             deviceHeader.appendChild(bulkExportBtn);
-            
+
             deviceSection.appendChild(deviceHeader);
-            
+
             // Render run history
             const historyDiv = document.createElement('div');
             historyDiv.className = 'run-history';
-            
+
             if (runs.length === 0) {
                 historyDiv.innerHTML = '<p class="loading">No data available</p>';
             } else {
@@ -659,16 +659,16 @@ class NetworkWatch {
                     historyDiv.appendChild(runEntry);
                 });
             }
-            
+
             deviceSection.appendChild(historyDiv);
-            
+
             // Add diff section for this device
             const diffSection = this.createDiffSection(command, device);
             deviceSection.appendChild(diffSection);
-            
+
             contentContainer.appendChild(deviceSection);
         }
-        
+
         // Restore diff states after rendering
         this.restoreDiffStates(command);
         this.restoreSideBySideScrollStates(command);
@@ -798,14 +798,14 @@ class NetworkWatch {
         this.outputViewModes[command] = 'snapshot';
         this.updateCommandData(command);
     }
-    
+
     renderSideBySideView(command, sideBySideData) {
         const contentContainer = document.getElementById('commandContent');
-        
+
         // Create side-by-side section
         const sideBySideSection = document.createElement('div');
         sideBySideSection.className = 'side-by-side-section';
-        
+
         const sectionHeader = document.createElement('div');
         sectionHeader.className = 'side-by-side-header';
 
@@ -814,41 +814,41 @@ class NetworkWatch {
         sectionHeader.appendChild(title);
         sectionHeader.appendChild(this.createOutputSnapshotControls(command, sideBySideData));
         sideBySideSection.appendChild(sectionHeader);
-        
+
         // Container for the two device outputs
         const comparisonContainer = document.createElement('div');
         comparisonContainer.className = 'comparison-container';
-        
+
         // Render each device
         sideBySideData.devices.forEach(deviceData => {
             const devicePanel = document.createElement('div');
             devicePanel.className = 'device-panel';
             devicePanel.dataset.deviceName = deviceData.name;
-            
+
             // Device header
             const header = document.createElement('div');
             header.className = 'device-panel-header';
-            
+
             const deviceName = document.createElement('h3');
             deviceName.textContent = deviceData.name;
             header.appendChild(deviceName);
-            
+
             // Metadata
             const meta = document.createElement('div');
             meta.className = 'device-panel-meta';
             const timestamp = this.formatTimestampJST(deviceData.run.ts_epoch);
             const duration = deviceData.run.duration_ms ? `${deviceData.run.duration_ms.toFixed(2)}ms` : 'N/A';
             meta.innerHTML = `
-                <span>${timestamp}</span> | 
+                <span>${timestamp}</span> |
                 Duration: ${duration}
                 ${deviceData.run.original_line_count ? ` | Lines: ${deviceData.run.original_line_count}` : ''}
             `;
             header.appendChild(meta);
-            
+
             // Badges
             const badges = document.createElement('div');
             badges.className = 'run-badges';
-            
+
             if (deviceData.run.ok) {
                 const badge = document.createElement('span');
                 badge.className = 'badge success';
@@ -860,30 +860,30 @@ class NetworkWatch {
                 badge.textContent = 'Error';
                 badges.appendChild(badge);
             }
-            
+
             if (deviceData.run.is_filtered) {
                 const badge = document.createElement('span');
                 badge.className = 'badge filtered';
                 badge.textContent = 'Filtered';
                 badges.appendChild(badge);
             }
-            
+
             if (deviceData.run.is_truncated) {
                 const badge = document.createElement('span');
                 badge.className = 'badge truncated';
                 badge.textContent = 'Truncated';
                 badges.appendChild(badge);
             }
-            
+
             header.appendChild(badges);
             devicePanel.appendChild(header);
-            
+
             // Output with character-level diff highlighting
             const outputContainer = document.createElement('div');
             outputContainer.className = 'device-panel-output';
             outputContainer.style.maxHeight = `${this.sideBySideOutputHeight}px`;
             outputContainer.style.height = `${this.sideBySideOutputHeight}px`;
-            
+
             if (deviceData.run.ok) {
                 const outputPre = document.createElement('pre');
                 outputPre.className = 'output-text-char-diff';
@@ -895,11 +895,11 @@ class NetworkWatch {
                 errorMsg.textContent = `Error: ${this.formatRunError(deviceData.run)}`;
                 outputContainer.appendChild(errorMsg);
             }
-            
+
             devicePanel.appendChild(outputContainer);
             comparisonContainer.appendChild(devicePanel);
         });
-        
+
         sideBySideSection.appendChild(comparisonContainer);
 
         const resizeHandle = document.createElement('div');
@@ -949,30 +949,30 @@ class NetworkWatch {
             this.setSideBySideOutputHeight(this.sideBySideOutputHeight + (step * direction));
         });
     }
-    
+
     createRunEntry(run, command, index) {
         const entry = document.createElement('div');
         entry.className = 'run-entry';
-        
+
         // Header
         const header = document.createElement('div');
         header.className = 'run-header';
-        
+
         const meta = document.createElement('div');
         meta.className = 'run-meta';
-        
+
         const timestamp = this.formatTimestampJST(run.ts_epoch);
         const duration = run.duration_ms ? `${run.duration_ms.toFixed(2)}ms` : 'N/A';
-        
+
         meta.innerHTML = `
-            <span class="timestamp">${timestamp}</span> | 
+            <span class="timestamp">${timestamp}</span> |
             Duration: ${duration}
             ${run.original_line_count ? ` | Lines: ${run.original_line_count}` : ''}
         `;
-        
+
         const badges = document.createElement('div');
         badges.className = 'run-badges';
-        
+
         if (run.ok) {
             const badge = document.createElement('span');
             badge.className = 'badge success';
@@ -984,28 +984,28 @@ class NetworkWatch {
             badge.textContent = 'Error';
             badges.appendChild(badge);
         }
-        
+
         if (run.is_filtered) {
             const badge = document.createElement('span');
             badge.className = 'badge filtered';
             badge.textContent = 'Filtered';
             badges.appendChild(badge);
         }
-        
+
         if (run.is_truncated) {
             const badge = document.createElement('span');
             badge.className = 'badge truncated';
             badge.textContent = 'Truncated';
             badges.appendChild(badge);
         }
-        
+
         header.appendChild(meta);
         header.appendChild(badges);
-        
+
         // Output (initially hidden)
         const output = document.createElement('div');
         output.className = 'run-output';
-        
+
         if (run.ok) {
             const outputText = document.createElement('pre');
             outputText.className = 'output-text';
@@ -1017,36 +1017,36 @@ class NetworkWatch {
             errorMsg.textContent = `Error: ${this.formatRunError(run)}`;
             output.appendChild(errorMsg);
         }
-        
+
         // Toggle visibility on header click
         header.addEventListener('click', () => {
             output.classList.toggle('visible');
         });
-        
+
         // Auto-expand first entry
         if (index === 0) {
             output.classList.add('visible');
         }
-        
+
         entry.appendChild(header);
         entry.appendChild(output);
-        
+
         // Add export buttons
         if (run.ok) {
             const exportControls = this.createExportControls(run, command, index);
             entry.appendChild(exportControls);
         }
-        
+
         return entry;
     }
-    
+
     createExportControls(run, command, index) {
         const controls = document.createElement('div');
         controls.className = 'export-controls';
-        
+
         // Get device name from the DOM context (will be set by parent)
         const deviceName = run._device || '';
-        
+
         const exportTextBtn = document.createElement('button');
         exportTextBtn.className = 'export-btn';
         exportTextBtn.textContent = '📄 Export as Text';
@@ -1054,7 +1054,7 @@ class NetworkWatch {
             e.stopPropagation();
             this.exportRun(command, deviceName, 'text');
         });
-        
+
         const exportJsonBtn = document.createElement('button');
         exportJsonBtn.className = 'export-btn';
         exportJsonBtn.textContent = '📋 Export as JSON';
@@ -1062,13 +1062,13 @@ class NetworkWatch {
             e.stopPropagation();
             this.exportRun(command, deviceName, 'json');
         });
-        
+
         controls.appendChild(exportTextBtn);
         controls.appendChild(exportJsonBtn);
-        
+
         return controls;
     }
-    
+
     exportRun(command, device, format) {
         try {
             const url = `/api/export/run?command=${encodeURIComponent(command)}&device=${encodeURIComponent(device)}&format=${format}`;
@@ -1078,7 +1078,7 @@ class NetworkWatch {
             alert('Failed to export data');
         }
     }
-    
+
     exportBulk(command) {
         try {
             const url = `/api/export/bulk?command=${encodeURIComponent(command)}&format=json`;
@@ -1088,30 +1088,30 @@ class NetworkWatch {
             alert('Failed to export bulk data');
         }
     }
-    
+
     createDiffSection(command, device) {
         const section = document.createElement('div');
         section.className = 'diff-section';
-        
+
         const header = document.createElement('h3');
         header.textContent = 'Diff Views';
         section.appendChild(header);
-        
+
         const controls = document.createElement('div');
         controls.className = 'diff-controls';
-        
+
         // History diff button
         const historyBtn = document.createElement('button');
         historyBtn.textContent = 'Show History Diff';
         historyBtn.addEventListener('click', () => this.showHistoryDiff(command, device));
         controls.appendChild(historyBtn);
-        
+
         // Device diff controls (if multiple devices)
         if (this.devices.length > 1) {
             const label = document.createElement('label');
             label.textContent = 'Compare with: ';
             controls.appendChild(label);
-            
+
             const select = document.createElement('select');
             this.devices.forEach(dev => {
                 if (dev !== device) {
@@ -1122,7 +1122,7 @@ class NetworkWatch {
                 }
             });
             controls.appendChild(select);
-            
+
             const deviceDiffBtn = document.createElement('button');
             deviceDiffBtn.textContent = 'Show Device Diff';
             deviceDiffBtn.addEventListener('click', () => {
@@ -1131,7 +1131,7 @@ class NetworkWatch {
             });
             controls.appendChild(deviceDiffBtn);
         }
-        
+
         section.appendChild(controls);
 
         // Diff output
@@ -1140,37 +1140,37 @@ class NetworkWatch {
         diffOutput.id = `diff-${device}`;
         diffOutput.textContent = this.DIFF_PLACEHOLDER_TEXT;
         section.appendChild(diffOutput);
-        
+
         // Diff export controls
         const exportControls = document.createElement('div');
         exportControls.className = 'diff-export-controls';
         exportControls.style.display = 'none';  // Hidden until diff is shown
         exportControls.id = `diff-export-${device}`;
-        
+
         const exportHtmlBtn = document.createElement('button');
         exportHtmlBtn.className = 'export-btn';
         exportHtmlBtn.textContent = '📄 Export Diff (HTML)';
         exportHtmlBtn.addEventListener('click', () => this.exportDiff(command, device, 'html'));
-        
+
         const exportTextBtn = document.createElement('button');
         exportTextBtn.className = 'export-btn';
         exportTextBtn.textContent = '📋 Export Diff (Text)';
         exportTextBtn.addEventListener('click', () => this.exportDiff(command, device, 'text'));
-        
+
         exportControls.appendChild(exportHtmlBtn);
         exportControls.appendChild(exportTextBtn);
         section.appendChild(exportControls);
-        
+
         return section;
     }
-    
+
     async showHistoryDiff(command, device) {
         try {
             const response = await fetch(
                 `/api/diff/history?command=${encodeURIComponent(command)}&device=${encodeURIComponent(device)}&origin_mode=previous`
             );
             const data = await response.json();
-            
+
             const diffOutput = document.getElementById(`diff-${device}`);
             this.renderDiff(
                 diffOutput,
@@ -1187,7 +1187,7 @@ class NetworkWatch {
                 exportControls.dataset.device = device;
                 exportControls.dataset.originMode = 'previous';
             }
-            
+
             // Save the diff state immediately
             const stateKey = `${command}:${device}`;
             this.diffStates[stateKey] = {
@@ -1208,7 +1208,7 @@ class NetworkWatch {
                 `/api/diff/devices?command=${encodeURIComponent(command)}&device_a=${encodeURIComponent(deviceA)}&device_b=${encodeURIComponent(deviceB)}`
             );
             const data = await response.json();
-            
+
             const diffOutputs = [
                 document.getElementById(`diff-${deviceA}`),
                 document.getElementById(`diff-${deviceB}`)
@@ -1222,7 +1222,7 @@ class NetworkWatch {
                     data.diff_format === 'html'
                 );
             });
-            
+
             // Show export controls and store diff context
             const exportControlTargets = [
                 document.getElementById(`diff-export-${deviceA}`),
@@ -1236,13 +1236,13 @@ class NetworkWatch {
                 exportControls.dataset.deviceA = deviceA;
                 exportControls.dataset.deviceB = deviceB;
             });
-            
+
             // Save the diff state for both devices
             // Only save if we have valid diff output
             if (diffOutputs && diffOutputs.length > 0 && diffOutputs[0]) {
                 const isHtml = diffOutputs[0].classList.contains('diff-output-html');
                 const content = diffOutputs[0].innerHTML;
-                
+
                 [deviceA, deviceB].forEach(device => {
                     const stateKey = `${command}:${device}`;
                     this.diffStates[stateKey] = {
@@ -1259,14 +1259,14 @@ class NetworkWatch {
             this.logClientError('DEVICE_DIFF_LOAD_FAILED', error, { command, deviceA, deviceB });
         }
     }
-    
+
     exportDiff(command, device, format) {
         const exportControls = document.getElementById(`diff-export-${device}`);
         if (!exportControls) return;
-        
+
         const diffType = exportControls.dataset.diffType;
         let url;
-        
+
         if (diffType === 'history') {
             const originMode = exportControls.dataset.originMode || 'previous';
             url = `/api/export/diff?command=${encodeURIComponent(command)}&device=${encodeURIComponent(device)}&format=${format}&origin_mode=${originMode}`;
@@ -1278,7 +1278,7 @@ class NetworkWatch {
             console.error('Unknown diff type');
             return;
         }
-        
+
         try {
             window.location.href = url;
         } catch (error) {
@@ -1350,31 +1350,31 @@ class NetworkWatch {
 
         element.innerHTML = html;
     }
-    
+
     saveDiffStates(command) {
         // Save the state of all visible diffs for the current command
         this.devices.forEach(device => {
             const diffOutputElement = document.getElementById(`diff-${device}`);
             const exportControlsElement = document.getElementById(`diff-export-${device}`);
-            
+
             if (!diffOutputElement || !exportControlsElement) {
                 return;
             }
-            
+
             // Check if there's actual diff content (not just the placeholder text)
             const hasContent = diffOutputElement.textContent !== this.DIFF_PLACEHOLDER_TEXT &&
                                diffOutputElement.innerHTML.trim().length > 0;
-            
+
             // Check if export controls are visible (more robust check)
             const isVisible = exportControlsElement.style.display === 'block' ||
-                            (exportControlsElement.style.display !== 'none' && 
+                            (exportControlsElement.style.display !== 'none' &&
                              exportControlsElement.offsetParent !== null);
-            
+
             if (hasContent && isVisible) {
                 const stateKey = `${command}:${device}`;
                 const diffType = exportControlsElement.dataset.diffType;
                 const otherDevice = exportControlsElement.dataset.deviceB;
-                
+
                 // Store the diff state
                 this.diffStates[stateKey] = {
                     type: diffType,
@@ -1391,30 +1391,30 @@ class NetworkWatch {
             }
         });
     }
-    
+
     restoreDiffStates(command) {
         // Restore previously visible diffs for the current command
         this.devices.forEach(device => {
             const stateKey = `${command}:${device}`;
             const state = this.diffStates[stateKey];
-            
+
             if (!state) {
                 return;
             }
-            
+
             const diffOutputElement = document.getElementById(`diff-${device}`);
             const exportControlsElement = document.getElementById(`diff-export-${device}`);
-            
+
             if (!diffOutputElement || !exportControlsElement) {
                 return;
             }
-            
+
             // Restore the diff content
             diffOutputElement.innerHTML = state.content;
             if (state.isHtml) {
                 diffOutputElement.classList.add('diff-output-html');
             }
-            
+
             // Restore export controls visibility and metadata
             exportControlsElement.style.display = 'block';
             exportControlsElement.dataset.diffType = state.type;
@@ -1425,90 +1425,114 @@ class NetworkWatch {
             }
         });
     }
-    
+
     async updatePingStatus() {
         try {
             const response = await fetch(
                 `/api/ping?window_seconds=${this.config.ping_window_seconds}`
             );
             const data = await response.json();
-            
+
             this.renderPingStatus(data.ping_status);
         } catch (error) {
             console.error('Error loading ping status:', error);
         }
     }
-    
+
     renderPingStatus(pingStatus) {
-        const container = document.getElementById('pingTiles');
-        container.innerHTML = '';
-        
+        const monitorContainer = document.getElementById('monitorPingTiles');
+        const deviceContainer = document.getElementById('devicePingTiles');
+        monitorContainer.innerHTML = '';
+        deviceContainer.innerHTML = '';
+
+        const deviceNames = new Set(this.devices);
+        let monitorCount = 0;
+        let deviceCount = 0;
+
         for (const [device, status] of Object.entries(pingStatus)) {
-            const tile = document.createElement('div');
-            tile.className = `ping-tile ${status.status}`;
-            
-            const header = document.createElement('h3');
-            header.textContent = device;
-            tile.appendChild(header);
-            
-            const stats = document.createElement('div');
-            stats.className = 'stats';
-            
-            const statusText = this.formatPingStatus(status);
-            stats.innerHTML = `
-                <div><strong>Status:</strong> ${statusText}</div>
-                <div><strong>Success Rate:</strong> ${status.success_rate.toFixed(1)}%</div>
-                <div><strong>Samples:</strong> ${status.successful_samples}/${status.total_samples}</div>
-                ${status.avg_rtt_ms ? `<div><strong>Avg RTT:</strong> ${status.avg_rtt_ms.toFixed(2)}ms</div>` : ''}
-                ${status.last_check_ts ? `<div><strong>Last Check:</strong> ${this.formatTimestampJST(status.last_check_ts)}</div>` : ''}
-                ${status.last_error_message ? `<div><strong>Last Error:</strong> ${this.escapeHtml(status.last_error_message)}</div>` : ''}
-            `;
-            
-            tile.appendChild(stats);
-
-            // Timeline tiles (oldest -> newest)
-            const timelineWrapper = document.createElement('div');
-            timelineWrapper.className = 'ping-timeline';
-
-            (status.timeline || []).forEach(result => {
-                const cell = document.createElement('div');
-                cell.className = 'ping-cell';
-                if (result === true) {
-                    cell.classList.add('ok');
-                } else if (result === false) {
-                    cell.classList.add('fail');
-                } else {
-                    cell.classList.add('unknown');
-                }
-                timelineWrapper.appendChild(cell);
-            });
-
-            tile.appendChild(timelineWrapper);
-            
-            // Add ping export buttons
-            const pingExportControls = document.createElement('div');
-            pingExportControls.className = 'ping-export-controls';
-            
-            const exportCsvBtn = document.createElement('button');
-            exportCsvBtn.className = 'export-btn-small';
-            exportCsvBtn.textContent = '📊 Export CSV';
-            exportCsvBtn.addEventListener('click', () => this.exportPing(device, 'csv'));
-            
-            const exportJsonBtn = document.createElement('button');
-            exportJsonBtn.className = 'export-btn-small';
-            exportJsonBtn.textContent = '📋 Export JSON';
-            exportJsonBtn.addEventListener('click', () => this.exportPing(device, 'json'));
-            
-            pingExportControls.appendChild(exportCsvBtn);
-            pingExportControls.appendChild(exportJsonBtn);
-            tile.appendChild(pingExportControls);
-            
-            container.appendChild(tile);
+            const tile = this.createPingTile(device, status);
+            if (deviceNames.has(device)) {
+                deviceContainer.appendChild(tile);
+                deviceCount += 1;
+            } else {
+                tile.classList.add('monitor-ping-tile');
+                monitorContainer.appendChild(tile);
+                monitorCount += 1;
+            }
         }
-        
+
         if (Object.keys(pingStatus).length === 0) {
-            container.innerHTML = '<p class="loading">No ping data available</p>';
+            monitorContainer.innerHTML = '<p class="loading">No ping data available</p>';
+        } else if (monitorCount === 0) {
+            monitorContainer.innerHTML = '<p class="loading">No standalone monitor data available</p>';
         }
+
+        if (deviceCount === 0 && Object.keys(pingStatus).length > 0) {
+            deviceContainer.innerHTML = '<p class="loading">No device ping data available</p>';
+        }
+    }
+
+    createPingTile(device, status) {
+        const tile = document.createElement('div');
+        tile.className = `ping-tile ${status.status}`;
+
+        const header = document.createElement('h3');
+        header.textContent = device;
+        tile.appendChild(header);
+
+        const stats = document.createElement('div');
+        stats.className = 'stats';
+
+        const statusText = this.formatPingStatus(status);
+        stats.innerHTML = `
+            <div><strong>Status:</strong> ${statusText}</div>
+            <div><strong>Success Rate:</strong> ${status.success_rate.toFixed(1)}%</div>
+            <div><strong>Samples:</strong> ${status.successful_samples}/${status.total_samples}</div>
+            ${status.avg_rtt_ms ? `<div><strong>Avg RTT:</strong> ${status.avg_rtt_ms.toFixed(2)}ms</div>` : ''}
+            ${status.last_check_ts ? `<div><strong>Last Check:</strong> ${this.formatTimestampJST(status.last_check_ts)}</div>` : ''}
+            ${status.last_error_message ? `<div><strong>Last Error:</strong> ${this.escapeHtml(status.last_error_message)}</div>` : ''}
+        `;
+
+        tile.appendChild(stats);
+
+        // Timeline tiles (oldest -> newest)
+        const timelineWrapper = document.createElement('div');
+        timelineWrapper.className = 'ping-timeline';
+
+        (status.timeline || []).forEach(result => {
+            const cell = document.createElement('div');
+            cell.className = 'ping-cell';
+            if (result === true) {
+                cell.classList.add('ok');
+            } else if (result === false) {
+                cell.classList.add('fail');
+            } else {
+                cell.classList.add('unknown');
+            }
+            timelineWrapper.appendChild(cell);
+        });
+
+        tile.appendChild(timelineWrapper);
+
+        // Add ping export buttons
+        const pingExportControls = document.createElement('div');
+        pingExportControls.className = 'ping-export-controls';
+
+        const exportCsvBtn = document.createElement('button');
+        exportCsvBtn.className = 'export-btn-small';
+        exportCsvBtn.textContent = '📊 Export CSV';
+        exportCsvBtn.addEventListener('click', () => this.exportPing(device, 'csv'));
+
+        const exportJsonBtn = document.createElement('button');
+        exportJsonBtn.className = 'export-btn-small';
+        exportJsonBtn.textContent = '📋 Export JSON';
+        exportJsonBtn.addEventListener('click', () => this.exportPing(device, 'json'));
+
+        pingExportControls.appendChild(exportCsvBtn);
+        pingExportControls.appendChild(exportJsonBtn);
+        tile.appendChild(pingExportControls);
+
+        return tile;
     }
 
     formatPingStatus(status) {
@@ -1524,7 +1548,7 @@ class NetworkWatch {
     formatRunError(run) {
         return run.error_message || 'Disconnected';
     }
-    
+
     exportPing(device, format) {
         try {
             const url = `/api/export/ping?device=${encodeURIComponent(device)}&format=${format}&window_seconds=3600`;
@@ -1534,22 +1558,22 @@ class NetworkWatch {
             alert('Failed to export ping data');
         }
     }
-    
+
     formatTimestampJST(epoch) {
         // Convert UTC epoch to JST
         const date = new Date(epoch * 1000);
-        
+
         // JST is UTC+9
         const jstOffset = 9 * 60; // minutes
         const jstDate = new Date(date.getTime() + jstOffset * 60 * 1000);
-        
+
         const year = jstDate.getUTCFullYear();
         const month = String(jstDate.getUTCMonth() + 1).padStart(2, '0');
         const day = String(jstDate.getUTCDate()).padStart(2, '0');
         const hours = String(jstDate.getUTCHours()).padStart(2, '0');
         const minutes = String(jstDate.getUTCMinutes()).padStart(2, '0');
         const seconds = String(jstDate.getUTCSeconds()).padStart(2, '0');
-        
+
         return `${year}-${month}-${day} ${hours}:${minutes}:${seconds} JST`;
     }
 }

--- a/src/nw_watch/webapp/static/debug.js
+++ b/src/nw_watch/webapp/static/debug.js
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026 icecake0141
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file was created or modified with the assistance of an AI (Large Language Model).
+ * Review required for correctness, security, and licensing.
+ */
+
+class DebugPage {
+    constructor() {
+        this.maxLines = 600;
+        this.streams = [];
+        this.bindControls();
+        this.startLogStream('app', 'appLogStream', 'appStreamStatus');
+        this.loadConfig();
+    }
+
+    bindControls() {
+        document.getElementById('clearDebugLogs').addEventListener('click', () => {
+            document.querySelectorAll('.ssh-device-log-stream').forEach(output => {
+                output.textContent = '';
+            });
+            document.getElementById('appLogStream').textContent = '';
+        });
+        document.getElementById('refreshDebugConfig').addEventListener('click', () => {
+            this.loadConfig();
+        });
+    }
+
+    startLogStream(name, outputId, statusId, params = {}) {
+        const output = document.getElementById(outputId);
+        const status = document.getElementById(statusId);
+        const query = new URLSearchParams(params).toString();
+        const source = new EventSource(
+            `/api/debug/logs/${name}${query ? `?${query}` : ''}`
+        );
+        this.streams.push(source);
+
+        source.addEventListener('status', event => {
+            status.textContent = event.data;
+            status.className = 'debug-stream-status connected';
+        });
+
+        source.addEventListener('log', event => {
+            const line = JSON.parse(event.data);
+            this.appendLine(output, line);
+        });
+
+        source.onerror = () => {
+            status.textContent = 'Reconnecting';
+            status.className = 'debug-stream-status reconnecting';
+        };
+    }
+
+    appendLine(output, line) {
+        const lines = output.textContent ? output.textContent.split('\n') : [];
+        if (lines.length === 1 && lines[0].startsWith('Waiting for')) {
+            lines.length = 0;
+        }
+        lines.push(line);
+        while (lines.length > this.maxLines) {
+            lines.shift();
+        }
+        output.textContent = lines.join('\n');
+        output.scrollTop = output.scrollHeight;
+    }
+
+    async loadConfig() {
+        const output = document.getElementById('debugConfig');
+        try {
+            const response = await fetch('/api/debug/config');
+            const data = await response.json();
+            const config = data.config || data;
+            output.textContent = JSON.stringify(config, null, 2);
+            this.renderSshDevicePanels(config.devices || []);
+        } catch (error) {
+            output.textContent = `Failed to load configuration: ${error}`;
+        }
+    }
+
+    renderSshDevicePanels(devices) {
+        const container = document.getElementById('sshDevicePanels');
+        const existingDeviceNames = new Set(
+            [...container.querySelectorAll('.debug-panel')].map(
+                panel => panel.dataset.deviceName
+            )
+        );
+        const nextDeviceNames = new Set(devices.map(device => device.name));
+
+        if (
+            existingDeviceNames.size === nextDeviceNames.size &&
+            [...nextDeviceNames].every(name => existingDeviceNames.has(name))
+        ) {
+            return;
+        }
+
+        this.streams = this.streams.filter(source => {
+            if (source.datasetType === 'ssh') {
+                source.close();
+                return false;
+            }
+            return true;
+        });
+        container.innerHTML = '';
+
+        if (devices.length === 0) {
+            container.innerHTML = '<p class="loading">No devices configured</p>';
+            return;
+        }
+
+        devices.forEach(device => {
+            const ids = this.deviceElementIds(device.name);
+            const panel = document.createElement('div');
+            panel.className = 'debug-panel';
+            panel.dataset.deviceName = device.name;
+            panel.innerHTML = `
+                <div class="debug-panel-header">
+                    <h2>SSH Session Console - ${this.escapeHtml(device.name)}</h2>
+                    <span id="${ids.statusId}" class="debug-stream-status">Connecting</span>
+                </div>
+                <pre id="${ids.outputId}" class="debug-log-stream ssh-device-log-stream">Waiting for ${this.escapeHtml(device.name)} SSH session logs...</pre>
+            `;
+            container.appendChild(panel);
+            this.startLogStream('ssh', ids.outputId, ids.statusId, { device: device.name });
+            this.streams[this.streams.length - 1].datasetType = 'ssh';
+        });
+    }
+
+    deviceElementIds(deviceName) {
+        const suffix = deviceName.replace(/[^a-zA-Z0-9_-]/g, '_');
+        return {
+            outputId: `sshLogStream_${suffix}`,
+            statusId: `sshStreamStatus_${suffix}`
+        };
+    }
+
+    escapeHtml(value) {
+        const div = document.createElement('div');
+        div.textContent = value;
+        return div.innerHTML;
+    }
+}
+
+window.addEventListener('beforeunload', () => {
+    if (window.debugPage) {
+        window.debugPage.streams.forEach(source => source.close());
+    }
+});
+
+document.addEventListener('DOMContentLoaded', () => {
+    window.debugPage = new DebugPage();
+});

--- a/src/nw_watch/webapp/static/style.css
+++ b/src/nw_watch/webapp/static/style.css
@@ -125,6 +125,7 @@ header h1 {
     border-radius: 4px;
     cursor: pointer;
     font-size: 14px;
+    text-decoration: none;
     transition: all 0.3s;
 }
 
@@ -134,6 +135,11 @@ header h1 {
 
 .btn:active {
     transform: scale(0.98);
+}
+
+.btn-small {
+    padding: 6px 10px;
+    font-size: 12px;
 }
 
 .btn-warning {
@@ -262,11 +268,56 @@ header h1 {
     gap: 15px;
 }
 
+.monitor-ping-tiles {
+    grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
+    margin-bottom: 16px;
+}
+
+.device-ping-tiles {
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+}
+
 .ping-tile {
     padding: 15px;
     border-radius: 6px;
     border-left: 4px solid;
     transition: all 0.3s;
+}
+
+.monitor-ping-tile {
+    display: grid;
+    grid-template-columns: minmax(250px, 0.9fr) minmax(280px, 1.4fr);
+    grid-template-rows: auto auto;
+    gap: 8px 18px;
+    align-items: center;
+    border-left-width: 6px;
+}
+
+.monitor-ping-tile h3 {
+    grid-column: 1;
+    margin-bottom: 2px;
+}
+
+.monitor-ping-tile .stats {
+    grid-column: 1;
+    grid-row: 2;
+    align-self: start;
+}
+
+.monitor-ping-tile .ping-timeline,
+.monitor-ping-tile .ping-export-controls {
+    grid-column: 2;
+}
+
+.monitor-ping-tile .ping-timeline {
+    grid-row: 1;
+    margin-top: 0;
+}
+
+.monitor-ping-tile .ping-export-controls {
+    grid-row: 2;
+    align-self: start;
+    margin-top: 8px;
 }
 
 .ping-tile.up {
@@ -752,6 +803,87 @@ header h1 {
     padding-top: 10px;
     border-top: 1px solid rgba(0, 0, 0, 0.1);
     justify-content: center;
+}
+
+/* Debug Page */
+.debug-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 16px;
+}
+
+.debug-device-panels {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+    gap: 16px;
+    grid-column: 1 / -1;
+}
+
+.debug-panel {
+    background: var(--bg-secondary);
+    border-radius: 8px;
+    box-shadow: 0 2px 4px var(--shadow-color);
+    min-height: 380px;
+    overflow: hidden;
+}
+
+.debug-config-panel {
+    grid-column: 1 / -1;
+}
+
+.debug-panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 14px 16px;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.debug-panel-header h2 {
+    margin: 0;
+    font-size: 16px;
+}
+
+.debug-stream-status {
+    color: var(--text-secondary);
+    font-size: 12px;
+}
+
+.debug-stream-status.connected {
+    color: var(--status-success);
+}
+
+.debug-stream-status.reconnecting {
+    color: var(--status-warning);
+}
+
+.debug-log-stream,
+.debug-config {
+    height: 340px;
+    margin: 0;
+    padding: 14px 16px;
+    overflow: auto;
+    background: #050806;
+    color: #7CFF9B;
+    font-family: "Monaco", "Menlo", "Ubuntu Mono", monospace;
+    font-size: 12px;
+    line-height: 1.45;
+    white-space: pre-wrap;
+}
+
+.debug-config {
+    height: 460px;
+}
+
+@media (max-width: 900px) {
+    .debug-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .debug-config-panel {
+        grid-column: auto;
+    }
 }
 
 /* Side-by-Side Comparison Styles */

--- a/src/nw_watch/webapp/templates/debug.html
+++ b/src/nw_watch/webapp/templates/debug.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<!--
+Copyright 2026 icecake0141
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+This file was created or modified with the assistance of an AI (Large Language Model).
+Review required for correctness, security, and licensing.
+-->
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Network Watch Debug</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>Network Watch - Debug</h1>
+            <div class="controls">
+                <a class="btn" href="/">← Monitor</a>
+                <button id="clearDebugLogs" class="btn">Clear Logs</button>
+            </div>
+        </header>
+
+        <section class="debug-grid">
+            <div id="sshDevicePanels" class="debug-device-panels">
+                <!-- Device-specific SSH log panels will be inserted here -->
+            </div>
+
+            <div class="debug-panel">
+                <div class="debug-panel-header">
+                    <h2>Application Log</h2>
+                    <span id="appStreamStatus" class="debug-stream-status">Connecting</span>
+                </div>
+                <pre id="appLogStream" class="debug-log-stream">Waiting for application logs...</pre>
+            </div>
+
+            <div class="debug-panel debug-config-panel">
+                <div class="debug-panel-header">
+                    <h2>Configuration</h2>
+                    <button id="refreshDebugConfig" class="btn btn-small">Refresh</button>
+                </div>
+                <pre id="debugConfig" class="debug-config">Loading configuration...</pre>
+            </div>
+        </section>
+    </div>
+
+    <script src="/static/debug.js"></script>
+</body>
+</html>

--- a/src/nw_watch/webapp/templates/index.html
+++ b/src/nw_watch/webapp/templates/index.html
@@ -24,6 +24,7 @@ Review required for correctness, security, and licensing.
         <header>
             <h1>Network Watch - Dual Device Monitor</h1>
             <div class="controls">
+                <a class="btn" href="/debug">Debug</a>
                 <button id="themeToggle" class="btn" title="Toggle dark mode">🌓 Theme</button>
                 <button id="toggleAutoRefresh" class="btn">⏸ Pause Auto-Refresh</button>
                 <button id="manualRefresh" class="btn">🔄 Refresh Now</button>
@@ -41,8 +42,11 @@ Review required for correctness, security, and licensing.
             <h2>Command Outputs</h2>
             <div class="ping-status command-monitoring-row">
                 <h2>Monitoring</h2>
-                <div id="pingTiles" class="ping-tiles">
-                    <!-- Ping tiles will be inserted here -->
+                <div id="monitorPingTiles" class="ping-tiles monitor-ping-tiles">
+                    <!-- Standalone monitor ping tiles will be inserted here -->
+                </div>
+                <div id="devicePingTiles" class="ping-tiles device-ping-tiles">
+                    <!-- Device ping tiles will be inserted here -->
                 </div>
             </div>
             <div id="commandTabs" class="tabs">

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -110,6 +110,62 @@ def test_index_page(client):
     assert "Network Watch" in response.text
 
 
+def test_debug_page_loads(client):
+    """Test debug page loads."""
+    response = client.get("/debug")
+    assert response.status_code == 200
+    assert "Network Watch - Debug" in response.text
+    assert "sshDevicePanels" in response.text
+
+
+def test_debug_config_masks_sensitive_values(client, tmp_path, monkeypatch):
+    """Test debug configuration masks secrets."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        """\
+interval_seconds: 5
+commands:
+  - name: version
+    command_text: show version
+devices:
+  - name: DeviceA
+    host: 192.0.2.1
+    username: admin
+    password: super-secret
+    password_env_key: DEVICE_PASSWORD
+    device_type: cisco_ios
+""",
+        encoding="utf-8",
+    )
+
+    from nw_watch.webapp import main
+
+    monkeypatch.setenv("NW_WATCH_CONFIG", str(config_path))
+    main.load_config.cache_clear()
+
+    try:
+        response = client.get("/api/debug/config")
+        assert response.status_code == 200
+        data = response.json()["config"]
+        assert data["devices"][0]["password"] == "********"
+        assert data["devices"][0]["password_env_key"] == "DEVICE_PASSWORD"
+        assert "super-secret" not in response.text
+    finally:
+        main.load_config.cache_clear()
+
+
+def test_resolve_ssh_log_device_tracks_multiline_output():
+    """Test SSH stream device filtering can keep multiline command output context."""
+    from nw_watch.webapp.main import resolve_ssh_log_device
+
+    current = resolve_ssh_log_device("[DeviceA] command> show version", None)
+    assert current == "DeviceA"
+    assert resolve_ssh_log_device("Cisco IOS XE Software", current) == "DeviceA"
+    assert (
+        resolve_ssh_log_device("[DeviceB] command> show version", current) == "DeviceB"
+    )
+
+
 def test_get_commands(client):
     """Test getting list of commands."""
     response = client.get("/api/commands")


### PR DESCRIPTION
## Summary
- Add a `/debug` GUI page with per-device SSH session streams, application log stream, and masked configuration view.
- Add debug log file helpers and wire app/collector processes to write streamable logs.
- Move monitor ping result tiles into a wide top section above device tiles.

## Rationale
This gives runtime visibility into SSH sessions and app behavior without exposing configured secrets in the browser.

## Validation
- `PYTHONPATH=src python -m black --check src/nw_watch/shared/debug.py src/nw_watch/collector/main.py src/nw_watch/runtime.py src/nw_watch/webapp/main.py tests/test_webapp.py`
- `PYTHONPATH=src python -m flake8 --ignore=E501,W503 src/nw_watch/shared/debug.py src/nw_watch/collector/main.py src/nw_watch/runtime.py src/nw_watch/webapp/main.py tests/test_webapp.py`
- `PYTHONPATH=src python -m mypy --ignore-missing-imports src`
- `PYTHONPATH=src python -m pytest -q tests/test_webapp.py`
- `PYTHONPATH=src python -m pytest -q tests/test_persistent_connections.py tests/test_collector.py`
- `git diff --check`
- `docker compose up -d --build`

## UI / Runtime Checks
- Opened `http://127.0.0.1:8000/debug` and verified separate `SSH Session Console - XE1` and `SSH Session Console - XE2` streams.
- Verified application log stream renders.
- Verified configuration view masks secrets and does not expose `cml12345`.
- Verified debug log panels use black background with bright green text.
- Verified persistent SSH behavior locally by observing repeated command execution without new SSH login messages after enabling persistent connections in local ignored config.

## LLM Involvement
Files created or modified with LLM assistance: `.gitignore`, `src/nw_watch/shared/debug.py`, `src/nw_watch/collector/main.py`, `src/nw_watch/runtime.py`, `src/nw_watch/webapp/main.py`, `src/nw_watch/webapp/static/app.js`, `src/nw_watch/webapp/static/debug.js`, `src/nw_watch/webapp/static/style.css`, `src/nw_watch/webapp/templates/index.html`, `src/nw_watch/webapp/templates/debug.html`, `tests/test_webapp.py`.
Human review performed: local browser/runtime verification, masked config inspection, per-device SSH stream inspection, and automated test/lint/type checks listed above.

## Notes
- Full `PYTHONPATH=src python -m flake8 src tests` is not clean on the existing repository because the current codebase has many pre-existing E501/F401/F841 findings outside this change. The changed Python files were checked with E501/W503 ignored to match the repository's Black formatting style.
- No `.pre-commit-config.yaml` is present, so pre-commit hooks were not available to run.
- `control/collector_control.json` is local runtime state and was intentionally not included in this PR.

## PR Checklist
- [x] License header added to new source files and top-level LICENSE present
- [x] LLM attribution added to modified/generated source files
- [x] Linting completed for changed Python files (command listed above)
- [x] Tests pass locally (commands listed above)
- [x] Static analysis/type checks pass (command listed above)
- [x] Formatting applied and checked (command listed above)
- [x] Pre-commit hooks checked: not configured
- [ ] CI build passes
- [x] No local merge conflicts observed on branch creation from current base
- [x] Documentation/UX surfaced through the new Debug nav and page
- [x] Examples/quick-start updated: not applicable
- [x] Commit message follows Conventional Commits
- [x] PR description includes summary, rationale, tests, docs/migration notes
- [x] PR description explicitly lists LLM-modified files and human review notes