### PR TITLE
[codex] Fix command error layout overflow

### DIFF
--- a/src/nw_watch/webapp/main.py
+++ b/src/nw_watch/webapp/main.py
@@ -431,6 +431,7 @@ async def get_runs_side_by_side(command: str):
                         "original_line_count": run_a.get("original_line_count"),
                         "output_text": text_a,
                         "output_html": highlighted_a,
+                        "error_message": run_a.get("error_message"),
                     },
                 },
                 {
@@ -444,6 +445,7 @@ async def get_runs_side_by_side(command: str):
                         "original_line_count": run_b.get("original_line_count"),
                         "output_text": text_b,
                         "output_html": highlighted_b,
+                        "error_message": run_b.get("error_message"),
                     },
                 },
             ],

--- a/src/nw_watch/webapp/static/app.js
+++ b/src/nw_watch/webapp/static/app.js
@@ -634,7 +634,10 @@ class NetworkWatch {
 
             const deviceHeader = document.createElement('div');
             deviceHeader.className = 'device-header-section';
-            deviceHeader.innerHTML = `<h3>Device: ${device}</h3>`;
+
+            const deviceTitle = document.createElement('h3');
+            deviceTitle.textContent = `Device: ${device}`;
+            deviceHeader.appendChild(deviceTitle);
 
             // Add bulk export button
             const bulkExportBtn = document.createElement('button');

--- a/src/nw_watch/webapp/static/style.css
+++ b/src/nw_watch/webapp/static/style.css
@@ -240,6 +240,9 @@ header h1 {
 
 /* Ping Status */
 .ping-status {
+    display: block;
+    clear: both;
+    width: 100%;
     background: var(--bg-secondary);
     padding: 20px;
     border-radius: 8px;
@@ -377,6 +380,9 @@ header h1 {
 
 /* Command Tabs */
 .command-tabs {
+    display: block;
+    clear: both;
+    width: 100%;
     background: var(--bg-secondary);
     padding: 20px;
     border-radius: 8px;
@@ -429,6 +435,9 @@ header h1 {
 }
 
 .device-section {
+    display: block;
+    clear: both;
+    width: 100%;
     margin-bottom: 30px;
 }
 
@@ -539,6 +548,11 @@ header h1 {
     padding: 10px;
     border-radius: 4px;
     border-left: 3px solid var(--status-error);
+    max-width: 100%;
+    overflow-x: auto;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    white-space: pre-wrap;
     transition: background-color 0.3s, color 0.3s;
 }
 
@@ -946,7 +960,7 @@ header h1 {
 
 .comparison-container {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
     gap: 20px;
     margin-top: 15px;
 }
@@ -954,6 +968,7 @@ header h1 {
 .device-panel {
     border: 1px solid #dee2e6;
     border-radius: 6px;
+    min-width: 0;
     overflow: hidden;
 }
 
@@ -979,6 +994,8 @@ header h1 {
     background: #f8f9fa;
     max-height: 600px;
     min-height: 240px;
+    min-width: 0;
+    overflow-x: auto;
     overflow-y: auto;
     resize: none;
 }

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -499,6 +499,31 @@ def test_get_runs_side_by_side(client):
     assert data["has_diff"] is True
 
 
+def test_get_runs_side_by_side_includes_error_message(client):
+    """Failed side-by-side runs should include the stored error message."""
+    db = Database("data/current.sqlite3")
+    db.insert_run(
+        device_name="DeviceB",
+        command_text="show version",
+        ts_epoch=1000003,
+        output_text="",
+        ok=False,
+        error_message="Failed to connect to DeviceB after 3 attempts",
+        duration_ms=3000.0,
+        original_line_count=0,
+    )
+    db.close()
+
+    response = client.get("/api/runs/show%20version/side_by_side")
+    assert response.status_code == 200
+
+    data = response.json()
+    device_b = next(device for device in data["devices"] if device["name"] == "DeviceB")
+    expected_error = "Failed to connect to DeviceB after 3 attempts"
+    assert device_b["run"]["ok"] == 0
+    assert device_b["run"]["error_message"] == expected_error
+
+
 def test_get_ping_status(client):
     """Test getting ping status."""
     response = client.get("/api/ping?window_seconds=60")


### PR DESCRIPTION
## Summary

Fixes Web UI layout breakage when device connection or command execution errors produce long error strings.

## Rationale

Failed command runs were stored with `error_message`, but the side-by-side API did not include that field, so the UI could only render `Unknown error` in that path. Long error text also lacked wrapping constraints, which could force side-by-side panels or page sections wider than their container and make Device / Ping Monitor areas appear beside each other or overflow.

## Changes

- Include `error_message` in `/api/runs/{command}/side_by_side` run payloads.
- Render device headers with `textContent` instead of `innerHTML` to avoid DOM/layout breakage from special characters.
- Add CSS constraints so Ping, Command, and Device sections remain block-level full-width containers.
- Add wrapping/overflow handling for long `.error-message` content and side-by-side panels.
- Add regression coverage for failed side-by-side runs carrying the stored error message.

## Validation

- `PYTHONPATH=/Users/daisukekoike/GitHub/nw-watch/src pytest -q` — 281 passed
- `PYTHONPATH=/Users/daisukekoike/GitHub/nw-watch/src black --check src tests` — passed
- `PYTHONPATH=/Users/daisukekoike/GitHub/nw-watch/src mypy src/nw_watch/webapp/main.py` — passed
- `PYTHONPATH=/Users/daisukekoike/GitHub/nw-watch/src flake8 --ignore=E501,W503 src/nw_watch/webapp/main.py tests/test_webapp.py` — passed
- `git diff --check` — passed

Additional checks attempted:

- `PYTHONPATH=/Users/daisukekoike/GitHub/nw-watch/src flake8 src tests` — fails on existing repo-wide E501/F401/F841/W503 style issues outside this PR's scope.
- `PYTHONPATH=/Users/daisukekoike/GitHub/nw-watch/src mypy src` — fails on existing missing `netmiko` type stubs in collector imports.
- Pre-commit hooks: no `.pre-commit-config.yaml` or `.pre-commit-config.yml` exists at the repository root.

## Documentation / Compatibility

No README or docs updates needed; this is a bug fix for existing Web UI behavior. No migration required.

## LLM Involvement

Files modified with LLM assistance:

- `src/nw_watch/webapp/main.py`
- `src/nw_watch/webapp/static/app.js`
- `src/nw_watch/webapp/static/style.css`
- `tests/test_webapp.py`

Human review: pending maintainer review. Codex reviewed the scoped diff and ran the validation commands above.

## Checklist

- [x] License header added to new files and top-level LICENSE present
- [x] LLM attribution added to modified/generated files
- [x] Tests pass locally (command: `PYTHONPATH=/Users/daisukekoike/GitHub/nw-watch/src pytest -q`)
- [x] Static analysis/type checks pass for changed backend surface (command: `PYTHONPATH=/Users/daisukekoike/GitHub/nw-watch/src mypy src/nw_watch/webapp/main.py`)
- [x] Formatting applied (command: `PYTHONPATH=/Users/daisukekoike/GitHub/nw-watch/src black --check src tests`)
- [x] No merge conflicts with base branch
- [x] Documentation updated or not applicable
- [x] Examples/quick-start updated or not applicable
- [x] Commit messages follow repository conventions
- [x] PR description includes summary, rationale, tests, docs, migration notes
- [x] PR description explicitly lists LLM-modified files and human review notes
- [ ] Linting completed — score: repo has existing flake8 failures; scoped command passed with existing E501/W503 ignored
- [ ] Pre-commit hooks pass — no repository root pre-commit config present
- [ ] CI build passes
- [ ] Changelog/versioning updated (not applicable for this bug fix)
