### PR TITLE
[codex] Fix startup device ping classification

### DIFF
--- a/src/nw_watch/webapp/main.py
+++ b/src/nw_watch/webapp/main.py
@@ -323,6 +323,18 @@ async def get_commands():
 @app.get("/api/devices")
 async def get_devices():
     """Get list of all devices."""
+    try:
+        config = load_config()
+        config_devices = [
+            device.get("name")
+            for device in config.get_devices()
+            if isinstance(device.get("name"), str) and device.get("name")
+        ]
+        if config_devices:
+            return JSONResponse({"devices": config_devices})
+    except (FileNotFoundError, PermissionError, YAMLError) as exc:
+        logger.warning("Config fallback for /api/devices: %s", exc)
+
     db = get_db(resolve_history_size())
     if not db:
         return JSONResponse({"devices": []})

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -202,6 +202,52 @@ def test_get_devices_excludes_ping_only_targets(client):
     assert "GatewayVIP" not in data["devices"]
 
 
+def test_get_devices_prefers_config_before_command_runs(client, tmp_path, monkeypatch):
+    """Test configured devices are returned before command runs exist."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        """\
+commands:
+  - name: version
+    command_text: show version
+ping_targets:
+  - name: GatewayVIP
+    host: 192.0.2.254
+devices:
+  - name: DeviceA
+    host: 192.0.2.1
+    username: admin
+    password: secret
+    device_type: cisco_ios
+  - name: DeviceB
+    host: 192.0.2.2
+    username: admin
+    password: secret
+    device_type: cisco_ios
+""",
+        encoding="utf-8",
+    )
+
+    db = Database("data/current.sqlite3")
+    db.insert_ping_sample(device_name="DeviceA", ts_epoch=1000002, ok=True, rtt_ms=1.0)
+    db.insert_ping_sample(
+        device_name="GatewayVIP", ts_epoch=1000002, ok=True, rtt_ms=1.0
+    )
+    db.close()
+
+    from nw_watch.webapp import main
+
+    monkeypatch.setenv("NW_WATCH_CONFIG", str(config_path))
+    main.load_config.cache_clear()
+
+    try:
+        response = client.get("/api/devices")
+        assert response.status_code == 200
+        assert response.json()["devices"] == ["DeviceA", "DeviceB"]
+    finally:
+        main.load_config.cache_clear()
+
+
 def test_get_runs(client):
     """Test getting command runs."""
     response = client.get("/api/runs/show%20version")


### PR DESCRIPTION
## Summary
- Prefer configured `devices[]` for `/api/devices` so startup rendering can classify Device ping tiles before command runs exist.
- Keep the existing database-derived device list as a fallback when config loading fails.
- Add a regression test for the startup state where ping data exists before command run data.

## Root Cause
On startup, ping collection can update `current.sqlite3` before command collection finishes. `/api/devices` previously inferred devices only from command run records, so the frontend could temporarily classify configured devices as standalone monitor targets until a browser reload after command data arrived.

## Validation
- `PYTHONPATH=/Users/daisukekoike/.codex/worktrees/62a4/nw-watch/src pytest tests/test_webapp.py -q`
- `PYTHONPATH=/Users/daisukekoike/.codex/worktrees/62a4/nw-watch/src pytest -q`
- `PYTHONPATH=/Users/daisukekoike/.codex/worktrees/62a4/nw-watch/src python -m black --check --target-version py311 src/nw_watch/webapp/main.py tests/test_webapp.py`
- `git diff --check`

CML / real-device testing was not run: this repository/worktree does not include CML lab inventory, credentials, or an executable real-device test harness. The change is confined to Web API classification and is covered by the regression test above.

## LLM Involvement
Files modified with LLM assistance:
- `src/nw_watch/webapp/main.py`
- `tests/test_webapp.py`

Human review note: local diff was inspected and automated tests were run before opening this PR.

## Checklist
- [x] License header added to new files and top-level LICENSE present
- [x] LLM attribution added to modified/generated files
- [x] Linting/formatting completed (command: `python -m black --check --target-version py311 src/nw_watch/webapp/main.py tests/test_webapp.py`)
- [x] Tests pass locally (command: `PYTHONPATH=/Users/daisukekoike/.codex/worktrees/62a4/nw-watch/src pytest -q`)
- [x] Static analysis/type checks pass or not applicable
- [x] Pre-commit hooks pass or not configured
- [ ] CI build passes
- [x] No merge conflicts with base branch at PR creation
- [x] Changelog/versioning updated or not applicable
- [x] Documentation updated or not applicable
- [x] Examples/quick-start updated or not applicable
- [x] Commit messages follow repository conventions
